### PR TITLE
Remove unifyConfigs and make unifyScripts more generic so that we can…

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,33 +11,24 @@ const keywordReplace = function(input, mappings) {
   return input;
 };
 
-const unifyFileMetaPairs = function(data, mainFileAttrName, metaFileAttrName, mappings) {
+const unifyScripts = function(data, mappings) {
   const converted = {};
   _.forEach(data, function(item) {
-    if (typeof item[metaFileAttrName] === 'object') {
-      item[metaFileAttrName] = JSON.stringify(item[metaFileAttrName]);
-    }
-    /* Meta file should always be JSON and therefore already parsed */
-
-    if (typeof item[mainFileAttrName] === 'object') {
-      item[mainFileAttrName] = JSON.stringify(item[mainFileAttrName]);
-    } else if (item[mainFileAttrName]) {
-      item[mainFileAttrName] = keywordReplace(item[mainFileAttrName], mappings);
-    }
+    _.keys(item)
+      .filter(function(key) { return key.endsWith('File'); })
+      .forEach(function(key) {
+        /* foreach attribute that ends in file, do a keyword replacement, or stringify it */
+        if (typeof item[key] === 'object') {
+          item[key] = JSON.stringify(item[key]);
+        } else if (item[key]) {
+          item[key] = keywordReplace(item[key], mappings);
+        }
+      });
 
     converted[item.name] = item;
   });
 
   return converted;
-};
-
-const unifyConfigs = function(data) {
-  /* These are both JSON files that shouldn't need to be re-mapped */
-  return unifyFileMetaPairs(data, 'configFile', 'metadataFile');
-};
-
-const unifyScripts = function(data, mappings) {
-  return unifyFileMetaPairs(data, 'scriptFile', 'metadataFile', mappings);
 };
 
 module.exports.parseJsonFile = function(fileName, contents, mappings) {
@@ -65,4 +56,3 @@ module.exports.unifyDatabases = function(data, mappings) {
 };
 
 module.exports.unifyScripts = unifyScripts;
-module.exports.unifyConfigs = unifyConfigs;

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -1,4 +1,4 @@
-const expect = require('expect');
+const expect = require('chai').expect;
 
 const utils = require('../src/utils');
 
@@ -10,19 +10,21 @@ describe('#utils', function() {
       scripts: [
         {
           name: 'login',
+          htmlFile: '<html>@@hello@@</html>',
           metadataFile: { b: 2 },
           scriptFile: { a: 1 }
         },
         {
           name: 'else',
-          metadataFile: '{"b":2}',
+          metadataFile: '{"b":@@two@@}',
           scriptFile: 'console.log(@@hello@@);'
         }
       ]
     } ];
 
     const mappings = {
-      hello: 'goodbye'
+      hello: 'goodbye',
+      two: 2
     };
 
     const expectation = [ {
@@ -30,6 +32,7 @@ describe('#utils', function() {
       scripts: {
         login: {
           name: 'login',
+          htmlFile: '<html>"goodbye"</html>',
           metadataFile: '{"b":2}',
           scriptFile: '{"a":1}'
         },
@@ -41,7 +44,7 @@ describe('#utils', function() {
       }
     } ];
 
-    expect(utils.unifyDatabases(data, mappings)).toEqual(expectation);
+    expect(utils.unifyDatabases(data, mappings)).to.deep.equal(expectation);
     done();
   });
 
@@ -54,7 +57,7 @@ describe('#utils', function() {
       },
       {
         name: 'client2',
-        metadataFile: '{"b":2}',
+        metadataFile: '{"b":@@two@@}',
         configFile: '{"a":1}'
       }
     ];
@@ -72,14 +75,14 @@ describe('#utils', function() {
       }
     };
 
-    expect(utils.unifyConfigs(data)).toEqual(expectation);
+    expect(utils.unifyScripts(data, { two: 2 })).to.deep.equal(expectation);
     done();
   });
 
   it('should parse json', function(done) {
     const string = '{ "a": 1 }';
 
-    expect(utils.parseJsonFile('test', string)).toEqual({ a: 1 });
+    expect(utils.parseJsonFile('test', string)).to.deep.equal({ a: 1 });
     done();
   });
 
@@ -110,7 +113,7 @@ describe('#utils', function() {
       },
       int_key: 5
     };
-    expect(utils.parseJsonFile('test2', contents, mappings)).toEqual(expectations);
+    expect(utils.parseJsonFile('test2', contents, mappings)).to.deep.equal(expectations);
     done();
   });
 
@@ -119,7 +122,7 @@ describe('#utils', function() {
 
     expect(function() {
       utils.parseJsonFile('test', string);
-    }).toThrow(/Error parsing JSON from metadata file: test/);
+    }).to.throw(/Error parsing JSON from metadata file: test/);
     done();
   });
 });


### PR DESCRIPTION
… handle keyword replacement cleaner, for bug: https://github.com/auth0/auth0-deploy-cli/issues/3

This change should be backwards compatible!

No let or arrow functions this time :)