### PR TITLE
Stop logging connection and rule files

### DIFF
--- a/src/auth0/connections.js
+++ b/src/auth0/connections.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const Promise = require('bluebird');
 const ValidationError = require('auth0-extension-tools').ValidationError;
 
+const utils = require('../utils');
 const constants = require('../constants');
 
 /*
@@ -71,7 +72,7 @@ const updateDatabase = function(progress, client, connections, database) {
   });
 
   progress.connectionsUpdated += 1;
-  progress.log('Updating database ' + connection.id + ': ' + JSON.stringify(options, null, 2));
+  progress.log('Updating database ' + connection.id + ': ' + JSON.stringify(options, utils.propertyReducer('scriptFile'), 2));
   return client.connections.update({ id: connection.id }, { options: options });
 };
 

--- a/src/auth0/connections.js
+++ b/src/auth0/connections.js
@@ -72,7 +72,7 @@ const updateDatabase = function(progress, client, connections, database) {
   });
 
   progress.connectionsUpdated += 1;
-  progress.log('Updating database ' + connection.id + ': ' + JSON.stringify(options, utils.propertyReducer('scriptFile'), 2));
+  progress.log('Updating database ' + connection.id + ': ' + JSON.stringify(options, utils.checksumReplacer(Object.keys(options.customScripts)), 2));
   return client.connections.update({ id: connection.id }, { options: options });
 };
 

--- a/src/auth0/rules.js
+++ b/src/auth0/rules.js
@@ -85,6 +85,10 @@ const updateRule = function(progress, client, existingRules, ruleName, ruleData,
     enabled: true
   };
 
+  if (typeof ruleData.scriptFile === 'string') {
+    payload.checksum = utils.generateChecksum(ruleData.scriptFile);
+  }
+
   progress.log('Processing rule ' + ruleName);
 
   // If a metadata file is provided, we'll apply these values to the rule.
@@ -106,13 +110,14 @@ const updateRule = function(progress, client, existingRules, ruleName, ruleData,
     applyMetadata();
 
     progress.rulesCreated += 1;
-    progress.log('Creating rule ' + ruleName + ': ' + JSON.stringify(payload, null, 2));
+    progress.log('Creating rule ' + ruleName + ': ' + JSON.stringify(payload, utils.propertyReducer('script'), 2));
 
     return client.rules.create(payload);
   }
 
   if (isExcluded && payload.script) {
     payload.script = null;
+    payload.checksum = null;
     progress.log('Ignoring script payload for manual rule: ' + ruleName);
   }
 
@@ -124,7 +129,7 @@ const updateRule = function(progress, client, existingRules, ruleName, ruleData,
 
   // Update the rule.
   progress.rulesUpdated += 1;
-  progress.log('Updating rule ' + ruleName + ' (' + existingRule.id + '):' + JSON.stringify(payload, null, 2));
+  progress.log('Updating rule ' + ruleName + ' (' + existingRule.id + '):' + JSON.stringify(payload, utils.propertyReducer('script'), 2));
   return client.rules.update({ id: existingRule.id }, payload);
 };
 

--- a/src/auth0/rules.js
+++ b/src/auth0/rules.js
@@ -85,10 +85,6 @@ const updateRule = function(progress, client, existingRules, ruleName, ruleData,
     enabled: true
   };
 
-  if (typeof ruleData.scriptFile === 'string') {
-    payload.checksum = utils.generateChecksum(ruleData.scriptFile);
-  }
-
   progress.log('Processing rule ' + ruleName);
 
   // If a metadata file is provided, we'll apply these values to the rule.
@@ -110,14 +106,13 @@ const updateRule = function(progress, client, existingRules, ruleName, ruleData,
     applyMetadata();
 
     progress.rulesCreated += 1;
-    progress.log('Creating rule ' + ruleName + ': ' + JSON.stringify(payload, utils.propertyReducer('script'), 2));
+    progress.log('Creating rule ' + ruleName + ': ' + JSON.stringify(payload, utils.checksumReplacer('script'), 2));
 
     return client.rules.create(payload);
   }
 
   if (isExcluded && payload.script) {
     payload.script = null;
-    payload.checksum = null;
     progress.log('Ignoring script payload for manual rule: ' + ruleName);
   }
 
@@ -129,7 +124,7 @@ const updateRule = function(progress, client, existingRules, ruleName, ruleData,
 
   // Update the rule.
   progress.rulesUpdated += 1;
-  progress.log('Updating rule ' + ruleName + ' (' + existingRule.id + '):' + JSON.stringify(payload, utils.propertyReducer('script'), 2));
+  progress.log('Updating rule ' + ruleName + ' (' + existingRule.id + '):' + JSON.stringify(payload, utils.checksumReplacer('script'), 2));
   return client.rules.update({ id: existingRule.id }, payload);
 };
 

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -2,7 +2,7 @@ const logger = require('./logger');
 const auth0 = require('./auth0');
 const pushToSlack = require('./slack');
 const appendProgress = require('./storage');
-const utils = require('../utils');
+const utils = require('./utils');
 
 const trackProgress = function(progressData) {
   const logs = [];
@@ -54,7 +54,7 @@ module.exports = function(progressData, context, client, storage, config, slackT
         rules: context.rules,
         pages: context.pages,
         databases: context.databases
-      }, utils.propertyReducer(['htmlFile', 'scriptFile']));
+      }, utils.checksumReplacer([ 'htmlFile', 'scriptFile' ]));
       progress.log('Assets: ' + assets, null, 2);
     })
     .then(function() {

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -2,6 +2,7 @@ const logger = require('./logger');
 const auth0 = require('./auth0');
 const pushToSlack = require('./slack');
 const appendProgress = require('./storage');
+const utils = require('../utils');
 
 const trackProgress = function(progressData) {
   const logs = [];
@@ -53,7 +54,7 @@ module.exports = function(progressData, context, client, storage, config, slackT
         rules: context.rules,
         pages: context.pages,
         databases: context.databases
-      });
+      }, utils.propertyReducer(['htmlFile', 'scriptFile']));
       progress.log('Assets: ' + assets, null, 2);
     })
     .then(function() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,7 +33,7 @@ const unifyScripts = function(data, mappings) {
   return converted;
 };
 
-module.exports.generateChecksum = function(data) {
+const generateChecksum = function(data) {
   if (typeof data !== 'string') {
     throw new ArgumentError('Must provide data as a string.');
   }
@@ -52,15 +52,16 @@ module.exports.parseJsonFile = function(fileName, contents, mappings) {
   }
 };
 
-module.exports.propertyReducer = function(exclusions) {
+module.exports.checksumReplacer = function(exclusions) {
   exclusions = exclusions || [];
   if (typeof exclusions === 'string') {
     exclusions = [ exclusions ];
   }
 
   return function(key, value) {
-    if (exclusions.includes(key)) {
-      return undefined;
+    if (exclusions.includes(key) && typeof value === 'string') {
+      const checksum = generateChecksum(value);
+      return checksum;
     }
 
     return value;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
+const crypto = require('crypto');
 const ValidationError = require('auth0-extension-tools').ValidationError;
+const ArgumentError = require('auth0-extension-tools').ArgumentError;
 
 const keywordReplace = function(input, mappings) {
   if (mappings && Object.keys(mappings).length > 0) {
@@ -31,6 +33,15 @@ const unifyScripts = function(data, mappings) {
   return converted;
 };
 
+module.exports.generateChecksum = function(data) {
+  if (typeof data !== 'string') {
+    throw new ArgumentError('Must provide data as a string.');
+  }
+
+  const checksum = crypto.createHash('sha256').update(data).digest('hex');
+  return checksum;
+};
+
 module.exports.parseJsonFile = function(fileName, contents, mappings) {
   try {
     /* if mappings is defined, replace contents before parsing */
@@ -39,6 +50,21 @@ module.exports.parseJsonFile = function(fileName, contents, mappings) {
     throw new ValidationError('Error parsing JSON from metadata file: ' + fileName + ', because: ' +
      JSON.stringify(e) + ', contents: ' + contents);
   }
+};
+
+module.exports.propertyReducer = function(exclusions) {
+  exclusions = exclusions || [];
+  if (typeof exclusions === 'string') {
+    exclusions = [ exclusions ];
+  }
+
+  return function(key, value) {
+    if (exclusions.includes(key)) {
+      return undefined;
+    }
+
+    return value;
+  };
 };
 
 module.exports.unifyDatabases = function(data, mappings) {

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -125,4 +125,105 @@ describe('#utils', function() {
     }).to.throw(/Error parsing JSON from metadata file: test/);
     done();
   });
+
+  it('should generate sha256 hex checksum with string', function(done) {
+    const string = 'Some string value';
+    const expectation = 'ec52355b4573bfac072b4fd2391e4b536edaabb09b55a4b71493b19fcf2461f1';
+
+    expect(utils.generateChecksum(string, expectation));
+    done();
+  });
+
+  it('should throw argument error for a checksum on a non-string', function(done) {
+    const nonstring = {};
+
+    expect(function() {
+      utils.generateChecksum(nonstring);
+    }).to.throw(/Must provide data as a string/);
+    done();
+  });
+
+  it('should reduce stringified JSON with array of parameter names', function(done) {
+    const object = {
+      prop1: 'value 1',
+      prop2: 'value 2',
+      prop3: 'value 3',
+      prop4: 'value 4',
+      prop5: 'value 5',
+      prop6: {
+        prop1: 'value 1',
+        prop2: 'value 2',
+        prop3: 'value 3'
+      }
+    };
+
+    const expectation = {
+      prop1: 'value 1',
+      prop2: 'value 2',
+      prop4: 'value 4',
+      prop6: {
+        prop1: 'value 1',
+        prop2: 'value 2'
+      }
+    };
+
+    const json = JSON.stringify(object, utils.propertyReducer([ 'prop3', 'prop5' ]));
+    const reducedObject = JSON.parse(json);
+
+    expect(reducedObject).to.deep.equal(expectation);
+    done();
+  });
+
+  it('should reduce stringified JSON with a single parameter name as a string', function(done) {
+    const object = {
+      prop1: 'value 1',
+      prop2: 'value 2',
+      prop3: 'value 3',
+      prop4: 'value 4',
+      prop5: 'value 5',
+      prop6: {
+        prop1: 'value 1',
+        prop2: 'value 2',
+        prop3: 'value 3'
+      }
+    };
+
+    const expectation = {
+      prop1: 'value 1',
+      prop2: 'value 2',
+      prop4: 'value 4',
+      prop5: 'value 5',
+      prop6: {
+        prop1: 'value 1',
+        prop2: 'value 2'
+      }
+    };
+
+    const json = JSON.stringify(object, utils.propertyReducer('prop3'));
+    const reducedObject = JSON.parse(json);
+
+    expect(reducedObject).to.deep.equal(expectation);
+    done();
+  });
+
+  it('should not impact stringified JSON with unspecified properties', function(done) {
+    const object = {
+      prop1: 'value 1',
+      prop2: 'value 2',
+      prop3: 'value 3',
+      prop4: 'value 4',
+      prop5: 'value 5',
+      prop6: {
+        prop1: 'value 1',
+        prop2: 'value 2',
+        prop3: 'value 3'
+      }
+    };
+
+    const json = JSON.stringify(object, utils.propertyReducer());
+    const reducedObject = JSON.parse(json);
+
+    expect(reducedObject).to.deep.equal(object);
+    done();
+  });
 });

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -126,23 +126,6 @@ describe('#utils', function() {
     done();
   });
 
-  it('should generate sha256 hex checksum with string', function(done) {
-    const string = 'Some string value';
-    const expectation = 'ec52355b4573bfac072b4fd2391e4b536edaabb09b55a4b71493b19fcf2461f1';
-
-    expect(utils.generateChecksum(string, expectation));
-    done();
-  });
-
-  it('should throw argument error for a checksum on a non-string', function(done) {
-    const nonstring = {};
-
-    expect(function() {
-      utils.generateChecksum(nonstring);
-    }).to.throw(/Must provide data as a string/);
-    done();
-  });
-
   it('should reduce stringified JSON with array of parameter names', function(done) {
     const object = {
       prop1: 'value 1',
@@ -160,14 +143,17 @@ describe('#utils', function() {
     const expectation = {
       prop1: 'value 1',
       prop2: 'value 2',
+      prop3: '5e2d78eb5107622b5441f53ac317fe431cebbfc2a04036c4ed820e11d54d6d1c',
       prop4: 'value 4',
+      prop5: '3db104a9dc47163e43226d0b25c4cabf082d1813a80d4d217b75a9c2b1e49ae8',
       prop6: {
         prop1: 'value 1',
-        prop2: 'value 2'
+        prop2: 'value 2',
+        prop3: '5e2d78eb5107622b5441f53ac317fe431cebbfc2a04036c4ed820e11d54d6d1c'
       }
     };
 
-    const json = JSON.stringify(object, utils.propertyReducer([ 'prop3', 'prop5' ]));
+    const json = JSON.stringify(object, utils.checksumReplacer([ 'prop3', 'prop5' ]));
     const reducedObject = JSON.parse(json);
 
     expect(reducedObject).to.deep.equal(expectation);
@@ -191,15 +177,17 @@ describe('#utils', function() {
     const expectation = {
       prop1: 'value 1',
       prop2: 'value 2',
+      prop3: '5e2d78eb5107622b5441f53ac317fe431cebbfc2a04036c4ed820e11d54d6d1c',
       prop4: 'value 4',
       prop5: 'value 5',
       prop6: {
         prop1: 'value 1',
-        prop2: 'value 2'
+        prop2: 'value 2',
+        prop3: '5e2d78eb5107622b5441f53ac317fe431cebbfc2a04036c4ed820e11d54d6d1c'
       }
     };
 
-    const json = JSON.stringify(object, utils.propertyReducer('prop3'));
+    const json = JSON.stringify(object, utils.checksumReplacer('prop3'));
     const reducedObject = JSON.parse(json);
 
     expect(reducedObject).to.deep.equal(expectation);
@@ -220,7 +208,7 @@ describe('#utils', function() {
       }
     };
 
-    const json = JSON.stringify(object, utils.propertyReducer());
+    const json = JSON.stringify(object, utils.checksumReplacer());
     const reducedObject = JSON.parse(json);
 
     expect(reducedObject).to.deep.equal(object);


### PR DESCRIPTION
Reduces the script file's from being logged.  This fixes issue #11.

Instead of logging the file a checksum is being generated and logged instead.  There is no need to log the contents of rules and database connection's action scripts.