### PR TITLE
Add support for simple keyword replacement.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,11 @@ const ArgumentError = require('auth0-extension-tools').ArgumentError;
 const keywordReplace = function(input, mappings) {
   if (mappings && Object.keys(mappings).length > 0) {
     Object.keys(mappings).forEach(function(key) {
+      const re = new RegExp('##' + key + '##', 'g');
+      input = input.replace(re, mappings[key]);
+    });
+
+    Object.keys(mappings).forEach(function(key) {
       const re = new RegExp('@@' + key + '@@', 'g');
       input = input.replace(re, JSON.stringify(mappings[key]));
     });
@@ -17,7 +22,9 @@ const unifyScripts = function(data, mappings) {
   const converted = {};
   _.forEach(data, function(item) {
     _.keys(item)
-      .filter(function(key) { return key.endsWith('File'); })
+      .filter(function(key) {
+        return key.endsWith('File');
+      })
       .forEach(function(key) {
         /* foreach attribute that ends in file, do a keyword replacement, or stringify it */
         if (typeof item[key] === 'object') {
@@ -43,12 +50,13 @@ const generateChecksum = function(data) {
 };
 
 module.exports.parseJsonFile = function(fileName, contents, mappings) {
+  let json = contents;
   try {
     /* if mappings is defined, replace contents before parsing */
-    return JSON.parse(keywordReplace(contents, mappings));
+    json = keywordReplace(contents, mappings);
+    return JSON.parse(json);
   } catch (e) {
-    throw new ValidationError('Error parsing JSON from metadata file: ' + fileName + ', because: ' +
-     JSON.stringify(e) + ', contents: ' + contents);
+    throw new ValidationError(`Error parsing JSON from metadata file: ${fileName}, because: ${e.message}, contents: ${contents}, post-replace: ${json}`);
   }
 };
 

--- a/tests/auth0/connections.tests.js
+++ b/tests/auth0/connections.tests.js
@@ -170,21 +170,6 @@ describe('#connections', () => {
         });
     });
 
-    it('should return error if trying to update forbidden script, get_user', (done) => {
-      connections.updateDatabases(progress, auth0, [ {
-        name: 'My-Other-Custom-DB',
-        scripts: {
-          get_user: {
-            scriptFile: ''
-          }
-        }
-      } ])
-        .catch((err) => {
-          expect(err.message).toEqual('The get_user script is not allowed for My-Other-Custom-DB.');
-          done();
-        });
-    });
-
     it('should return error if trying to update forbidden script, change_email and no get_user', (done) => {
       connections.updateDatabases(progress, auth0, [ {
         name: 'My-Other-Custom-DB',

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -117,6 +117,44 @@ describe('#utils', function() {
     done();
   });
 
+  it('should parse json with keyword replacement mappings, new method', function(done) {
+    const mappings = {
+      string: 'some string',
+      array: [
+        'some value',
+        'some other value'
+      ],
+      object: {
+        key1: 'value1',
+        key2: 'value2'
+      },
+      int: 5
+    };
+
+    const contents = '{ "a": 1, "string_key": @@string@@, "array_key": @@array@@, "object_key": @@object@@,' +
+      ' "int_key": @@int@@, "simple_string_key": "Some ##string##", "simple_array_key": "Some' +
+      ' ##array##", "simple_object_key": "Some ##object##", "simple_int_key": ##int## }';
+    const expectations = {
+      a: 1,
+      string_key: 'some string',
+      array_key: [
+        'some value',
+        'some other value'
+      ],
+      object_key: {
+        key1: 'value1',
+        key2: 'value2'
+      },
+      int_key: 5,
+      simple_string_key: 'Some some string',
+      simple_array_key: 'Some some value,some other value',
+      simple_object_key: 'Some [object Object]',
+      simple_int_key: 5
+    };
+    expect(utils.parseJsonFile('test2.5', contents, mappings)).to.deep.equal(expectations);
+    done();
+  });
+
   it('should throw error if cannot parse json', function(done) {
     const string = 'json?';
 


### PR DESCRIPTION
There have been some requests for the ability to do a keyword
replacement within a string.  This restricts that ability to do full
JSON replacements, so adding a new way to pass mappings in that allow
for separation of simple and json mappings.

Also added some better error reporting for bad JSON files.  The error
message was previously getting squashed and it wasn't printing the
post-keyword replacement JSON.  Now it prints the error message right,
and adds the post-replacement JSON.  So you can compare pre and post.

@sandrinodimattia which team am I supposed to bug for PR's on this repo now?