### PR TITLE
Trim big scripts before saving

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -6,6 +6,15 @@ const _ = require('lodash');
 module.exports = function(storage, progress) {
   return storage.read()
     .then(function(data) {
+      progress.rules = _.map(progress.rules || [], function(rule) {
+        // trimming big scripts
+        if (rule.script.length > 500) {
+          rule.script = rule.script.substr(0, 500) + '...';
+        }
+
+        return rule;
+      });
+
       data.deployments = data.deployments || [];
       data.deployments.push(progress);
       if (data.deployments.length > 10) {


### PR DESCRIPTION
Currently, we're saving too much data to the wt storage. Even last 10 deployments may reach storage limits in case of large rules, as we're saving entire rule code. So i'd suggest to trim big scripts, before saving them to the storage.
What do you think?