### PR TITLE
Add the ability to exclude new rules by including them in the list of rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Supporting tools for the Source Control extensions",
   "main": "src/index.js",
   "scripts": {

--- a/src/auth0/rules.js
+++ b/src/auth0/rules.js
@@ -100,6 +100,11 @@ const updateRule = function(progress, client, existingRules, ruleName, ruleData,
 
   const existingRule = _.find(existingRules, { name: ruleName });
   if (!existingRule) {
+    if (isExcluded) {
+      progress.log('Ignoring creation request for manual rule: ' + ruleName + ': ' + JSON.stringify(payload, utils.checksumReplacer('script'), 2));
+      return Promise.resolve(true);
+    }
+
     payload.stage = 'login_success';
     payload.enabled = true;
 

--- a/tests/auth0/rules.tests.js
+++ b/tests/auth0/rules.tests.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 const expect = require('expect');
 const Promise = require('bluebird');
 
@@ -28,6 +30,15 @@ describe('#rules', () => {
       metadataFile: '{ "order": 30, "enabled": false }'
     }
   };
+
+  const filesWithExtraCreate = _.assign({}, files, {
+    'new-lame-rule': {
+      script: true,
+      scriptFile: 'function newLameRule() { }',
+      metadata: true,
+      metadataFile: '{ "order": 40, "enabled": true }'
+    }
+  });
 
   const filesBroken = {
     'broken-file': {
@@ -186,6 +197,14 @@ describe('#rules', () => {
       rules.updateRules(progress, auth0, filesBroken, [ 'foo' ])
         .catch((err) => {
           expect(err.message).toEqual('ERROR');
+          done();
+        });
+    });
+
+    it('should not add rule if the rule is excluded', (done) => {
+      rules.updateRules(progress, auth0, filesWithExtraCreate, [ 'new-lame-rule' ])
+        .then(() => {
+          expect(progress.rulesCreated).toEqual(0);
           done();
         });
     });


### PR DESCRIPTION
The use case presented is that there are rules that they might want to have deployed to dev, but not to production or vice versa.