### PR TITLE
Prevent history from exceeding 500KB

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Supporting tools for the Source Control extensions",
   "main": "src/index.js",
   "scripts": {

--- a/src/storage.js
+++ b/src/storage.js
@@ -32,7 +32,22 @@ module.exports = function(storage, progress) {
 
       // Adding new historical record for latest deployment.
       data.deployments = data.deployments || [];
-      progress = exceedsMaximumBytes(progress) ? { message: 'Logs exceeded maximum storage' } : progress;
+      if (exceedsMaximumBytes(progress)) {
+        progress = {
+          id: progress.id,
+          user: progress.user,
+          branch: progress.branch,
+          repository: progress.repository,
+          date: progress.date,
+          connectionsUpdated: progress.connectionsUpdated,
+          rulesCreated: progress.rulesCreated,
+          rulesUpdated: progress.rulesUpdated,
+          rulesDeleted: progress.rulesDeleted,
+          error: progress.error,
+          message: 'This log entry has exceeded the maximum allowed size and data has been redacted to reduce the total size.'
+        };
+      }
+
       data.deployments.push(progress);
 
       data = trimLogs(data);

--- a/src/storage.js
+++ b/src/storage.js
@@ -6,10 +6,12 @@ const _ = require('lodash');
 module.exports = function(storage, progress) {
   // Trimming the history to a maximum of 10 records and 490KB (keeping a 10KB buffer).
   function trimLogs(data) {
-    var dataSize = JSON.stringify(data).length;
-    while (dataSize >= 490000 || data.deployments.length > 10) {
-      data.deployments = _.drop(data.deployments, data.deployments.length - 10);
-      dataSize = JSON.stringify(data).length;
+    const maximumBytes = 490000;
+    var dataSize = Buffer.from(JSON.stringify(data)).length;
+
+    while (dataSize >= maximumBytes || data.deployments.length > 10) {
+      data.deployments = _.drop(data.deployments, 1);
+      dataSize = Buffer.from(JSON.stringify(data)).byteLength;
     }
 
     return data;

--- a/src/storage.js
+++ b/src/storage.js
@@ -44,7 +44,11 @@ module.exports = function(storage, progress) {
           rulesUpdated: progress.rulesUpdated,
           rulesDeleted: progress.rulesDeleted,
           error: progress.error,
-          message: 'This log entry has exceeded the maximum allowed size and data has been redacted to reduce the total size.'
+          sha: progress.sha,
+          logs: [ {
+            date: '2018-02-23T19:45:01.965Z',
+            message: 'This log entry has exceeded the maximum allowed size and data has been redacted to reduce the total size.'
+          } ]
         };
       }
 

--- a/tests/storage.tests.js
+++ b/tests/storage.tests.js
@@ -1,3 +1,5 @@
+const crypto = require('crypto');
+const expect = require('expect');
 const Promise = require('bluebird');
 const store = require('../src/storage');
 
@@ -13,12 +15,44 @@ describe('#write logs to storage', () => {
 });
 
 describe('#write logs to storage', () => {
-  it('should update logs with 11 or more records', (done) => {
+  it('should remove oldest logs and push news deploy to history', (done) => {
     const storage = {
-      read: () => Promise.resolve({ deployments: [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ] }),
-      write: () => Promise.resolve({})
+      read: () => Promise.resolve({ deployments: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ] }),
+      write: (newData) => {
+        expect(newData.deployments.length).toBe(10);
+        expect(newData.deployments[0]).toBe(8);
+        return Promise.resolve({});
+      }
     };
 
     store(storage, '').then(() => done());
+  });
+
+  it('should remove oldest history when total history size exceeds 490KB, but not exceed length', (done) => {
+    var deployments = [];
+
+    // Generate 9 random strings of 54,444 bytes.
+    deployments.push(crypto.randomBytes(27222).toString('hex'));
+    deployments.push(crypto.randomBytes(27222).toString('hex'));
+    deployments.push(crypto.randomBytes(27222).toString('hex'));
+    deployments.push(crypto.randomBytes(27222).toString('hex'));
+    deployments.push(crypto.randomBytes(27222).toString('hex'));
+    deployments.push(crypto.randomBytes(27222).toString('hex'));
+    deployments.push(crypto.randomBytes(27222).toString('hex'));
+    deployments.push(crypto.randomBytes(27222).toString('hex'));
+    deployments.push(crypto.randomBytes(27222).toString('hex'));
+
+    const storage = {
+      read: () => Promise.resolve({
+        deployments: deployments
+      }),
+      write: (newData) => {
+        expect(newData.deployments.length).toBe(9);
+        expect(newData.deployments[newData.deployments.length - 1]).toBe('test');
+        return Promise.resolve({});
+      }
+    };
+
+    store(storage, 'test').then(() => done());
   });
 });

--- a/tests/storage.tests.js
+++ b/tests/storage.tests.js
@@ -74,7 +74,11 @@ describe('#write logs to storage', () => {
       rulesDeleted: 9,
       error: 10,
       junk: massiveBlob,
-      message: 'This log entry has exceeded the maximum allowed size and data has been redacted to reduce the total size.'
+      sha: 'sha',
+      logs: [ {
+        date: '2018-02-23T19:45:01.965Z',
+        message: 'This log entry has exceeded the maximum allowed size and data has been redacted to reduce the total size.'
+      } ]
     };
 
     const storage = {
@@ -84,9 +88,10 @@ describe('#write logs to storage', () => {
       write: (newData) => {
         var currentLog = newData.deployments[newData.deployments.length - 1];
         expect(newData.deployments.length).toBe(5);
-        expect(currentLog.id).toBe(1);
-        expect(currentLog.user).toBe(2);
-        expect(currentLog.date).toBe(5);
+        expect(currentLog.id).toBe(progress.id);
+        expect(currentLog.user).toBe(progress.user);
+        expect(currentLog.date).toBe(progress.date);
+        expect(currentLog.sha).toBe(progress.sha);
         expect(currentLog.message).toBe(progress.message);
         expect(currentLog.junk).toBe(undefined);
 


### PR DESCRIPTION
This is an attempt to further mitigate the likelihood the deployment history will exceed the 500K storage limits.  This PR will remove the oldest history records until there is enough space to store the most recent record.  If the newest record will exceed the maximum storage size in its own right most of the blob data will be removed.  The new schema will look something like this:

```
var progress = {
      id: 1,
      user: 2,
      branch: 3,
      repository: 4,
      date: 5,
      connectionsUpdated: 6,
      rulesCreated: 7,
      rulesUpdated: 8,
      rulesDeleted: 9,
      error: 10,
      message: 'This log entry has exceeded the maximum allowed size and data has been redacted to reduce the total size.'
    };
```

The remaining data should preserve some useful details, but will surely remove the variable sized data ensuring it will not, on its own, exceed the limits.