### PR TITLE
Support for email template, email provider and connection options+metadata

### DIFF
--- a/src/auth0/connections.js
+++ b/src/auth0/connections.js
@@ -42,7 +42,14 @@ const updateDatabase = function(progress, client, connections, database) {
     );
   }
 
-  const options = connection.options || {};
+  // Read configuration to be deployed. Possible keys:
+  // - options
+  // - metadata
+  const configuration = database.configuration || {};
+
+  const metadata = _.extend(connection.metadata || {}, configuration.metadata || {});
+
+  const options = _.extend(connection.options || {}, configuration.options || {});
   options.customScripts = {};
 
   const databaseScriptKeys = Object.keys(database.scripts);
@@ -75,7 +82,10 @@ const updateDatabase = function(progress, client, connections, database) {
 
   progress.connectionsUpdated += 1;
   progress.log('Updating database ' + connection.id + ': ' + JSON.stringify(options, utils.checksumReplacer(Object.keys(options.customScripts)), 2));
-  return apiCall(client, client.connections.update, [ { id: connection.id }, { options: options } ]);
+  return apiCall(client, client.connections.update, [ { id: connection.id }, {
+    metadata: metadata,
+    options: options
+  } ]);
 };
 
 /*

--- a/src/auth0/connections.js
+++ b/src/auth0/connections.js
@@ -52,6 +52,18 @@ const updateDatabase = function(progress, client, connections, database) {
   const options = _.extend(connection.options || {}, configuration.options || {});
   options.customScripts = {};
 
+  // Special handling of custom DB configuration, where values are encrypted. The client
+  // can send 'options.bareConfiguration' with plain text values, and the server will
+  // encrypt them. In this case, don't send 'options.configuration' for two reasons:
+  // 1. bareConfiguration values take precedence anyway.
+  // 2. It allows us to remove old configuration key/values.
+  // In other words, if 'options.bareConfiguration' is present we assume it represents
+  // the entire set of key/values. If not, we keep 'options.configuration' just as
+  // before.
+  if (options.bareConfiguration) {
+    delete options.configuration;
+  }
+
   const databaseScriptKeys = Object.keys(database.scripts);
 
   allowedScripts = (options.import_mode) ? constants.DATABASE_SCRIPTS_IMPORT : constants.DATABASE_SCRIPTS_NO_IMPORT;

--- a/src/auth0/emailProviders.js
+++ b/src/auth0/emailProviders.js
@@ -25,7 +25,15 @@ const updateEmailProvider = function(progress, client, files) {
   }
 
   progress.log('Updating email provider...');
-  return apiCall(client, client.emailProvider.update, [ {}, payload ]).then(() => true);
+  return apiCall(client, client.emailProvider.update, [ {}, payload ])
+    .then(() => true)
+    .catch((result) => {
+      if (result.statusCode === 404) {
+        progress.log('Email provider doesn\'t exist, configuring it...');
+        return apiCall(client, client.emailProvider.configure, [ payload ]);
+      }
+      return Promise.reject(result);
+    });
 };
 
 module.exports = {

--- a/src/auth0/emailProviders.js
+++ b/src/auth0/emailProviders.js
@@ -26,7 +26,7 @@ const updateEmailProvider = function(progress, client, files) {
   }
 
   progress.log('Updating email provider...');
-  return apiCall(client, client.emailProvider.update, [ payload ]).then(() => true);
+  return apiCall(client, client.emailProvider.update, [ {}, payload ]).then(() => true);
 };
 
 module.exports = {

--- a/src/auth0/emailProviders.js
+++ b/src/auth0/emailProviders.js
@@ -1,8 +1,7 @@
-// const _ = require('lodash');
 const Promise = require('bluebird');
 
 const utils = require('../utils');
-// const constants = require('../constants');
+const constants = require('../constants');
 const apiCall = require('./apiCall');
 
 /**
@@ -11,7 +10,7 @@ const apiCall = require('./apiCall');
  * a single email provider.
  */
 const getEmailProviderObject = function(files, mappings) {
-  const file = files.default;
+  const file = files[constants.EMAIL_PROVIDER_NAME];
   if (!file) {
     return null;
   }

--- a/src/auth0/emailProviders.js
+++ b/src/auth0/emailProviders.js
@@ -1,0 +1,35 @@
+// const _ = require('lodash');
+const Promise = require('bluebird');
+
+const utils = require('../utils');
+// const constants = require('../constants');
+const apiCall = require('./apiCall');
+
+/**
+ * Get an email provider object from the files object.
+ * Currently always gets the one named 'default', as there can only be
+ * a single email provider.
+ */
+const getEmailProviderObject = function(files, mappings) {
+  const file = files.default;
+  if (!file) {
+    return null;
+  }
+
+  return utils.parseJsonFile(file.name, file.configFile, mappings);
+};
+
+const updateEmailProvider = function(progress, client, files) {
+  const payload = getEmailProviderObject(files, progress.mappings);
+  if (!payload) {
+    return Promise.resolve(true);
+  }
+
+  progress.log('Updating email provider...');
+  return apiCall(client, client.emailProvider.update, [ payload ]).then(() => true);
+};
+
+module.exports = {
+  getEmailProviderObject: getEmailProviderObject,
+  updateEmailProvider: updateEmailProvider
+};

--- a/src/auth0/emailTemplates.js
+++ b/src/auth0/emailTemplates.js
@@ -6,22 +6,6 @@ const constants = require('../constants');
 const apiCall = require('./apiCall');
 
 /**
- * Get an e-mail template
- */
-const getEmailTemplateByName = function(progress, client, name) {
-  if (progress.emailTemplates && progress.emailTemplates[name]) {
-    return Promise.resolve(progress.emailTemplates[name]);
-  }
-
-  return apiCall(client, client.emailTemplates.get, [ { name: name } ])
-    .then(function(emailTemplate) {
-      progress.emailTemplates = progress.emailTemplates || {};
-      progress.emailTemplates[name] = emailTemplate;
-      return emailTemplate;
-    });
-};
-
-/**
  * Get an email template object from the files object.
  */
 const getEmailTemplateObject = function(files, name, mappings) {
@@ -53,8 +37,6 @@ const updateEmailTemplateByName = function(progress, client, files, name) {
   }
 
   progress.log('Updating email template "' + name + '"...');
-  // Hm, do we need to use Create sometimes?
-  // But the API docs for getEmailTemplateByName doesn't contain 404..
   return apiCall(client, client.emailTemplates.update, [ { name: name }, tpl ]).then(() => true);
 };
 
@@ -69,7 +51,6 @@ const updateAllEmailTemplates = function(progress, client, files) {
 };
 
 module.exports = {
-  getEmailTemplateByName: getEmailTemplateByName,
   getEmailTemplateObject: getEmailTemplateObject,
   updateEmailTemplateByName: updateEmailTemplateByName,
   updateAllEmailTemplates: updateAllEmailTemplates

--- a/src/auth0/emailTemplates.js
+++ b/src/auth0/emailTemplates.js
@@ -24,7 +24,8 @@ const getEmailTemplateObject = function(files, name, mappings) {
 
   if (file.metadata) {
     const metadata = utils.parseJsonFile(name, file.metadataFile, mappings);
-    tpl = _.assign(tpl, metadata);
+    // 'template' and 'body' are set above and cannot be overridden with metadata
+    tpl = _.assign(tpl, _.omit(metadata, [ 'body', 'template' ]));
   }
 
   return tpl;

--- a/src/auth0/emailTemplates.js
+++ b/src/auth0/emailTemplates.js
@@ -38,7 +38,15 @@ const updateEmailTemplateByName = function(progress, client, files, name) {
   }
 
   progress.log('Updating email template "' + name + '"...');
-  return apiCall(client, client.emailTemplates.update, [ { name: name }, tpl ]).then(() => true);
+  return apiCall(client, client.emailTemplates.update, [ { name: name }, tpl ])
+    .then(() => true)
+    .catch((result) => {
+      if (result.statusCode === 404) {
+        progress.log('Email template ' + name + ' doesn\'t exist, creating it...');
+        return apiCall(client, client.emailTemplates.create, [ tpl ]);
+      }
+      return Promise.reject(result);
+    });
 };
 
 const updateAllEmailTemplates = function(progress, client, files) {

--- a/src/auth0/emailTemplates.js
+++ b/src/auth0/emailTemplates.js
@@ -1,0 +1,76 @@
+const _ = require('lodash');
+const Promise = require('bluebird');
+
+const utils = require('../utils');
+const constants = require('../constants');
+const apiCall = require('./apiCall');
+
+/**
+ * Get an e-mail template
+ */
+const getEmailTemplateByName = function(progress, client, name) {
+  if (progress.emailTemplates && progress.emailTemplates[name]) {
+    return Promise.resolve(progress.emailTemplates[name]);
+  }
+
+  return apiCall(client, client.emailTemplates.get, [ { name: name } ])
+    .then(function(emailTemplate) {
+      progress.emailTemplates = progress.emailTemplates || {};
+      progress.emailTemplates[name] = emailTemplate;
+      return emailTemplate;
+    });
+};
+
+/**
+ * Get an email template object from the files object.
+ */
+const getEmailTemplateObject = function(files, name, mappings) {
+  var tpl;
+  const file = files[name];
+  if (!file) {
+    return null;
+  }
+
+  // Default to enabled:false since we need metadata!
+  tpl = {
+    template: name,
+    body: file.htmlFile,
+    enabled: false
+  };
+
+  if (file.metadata) {
+    const metadata = utils.parseJsonFile(name, file.metadataFile, mappings);
+    tpl = _.assign(tpl, metadata);
+  }
+
+  return tpl;
+};
+
+const updateEmailTemplateByName = function(progress, client, files, name) {
+  const tpl = getEmailTemplateObject(files, name, progress.mappings);
+  if (!tpl) {
+    return Promise.resolve(true);
+  }
+
+  progress.log('Updating email template "' + name + '"...');
+  // Hm, do we need to use Create sometimes?
+  // But the API docs for getEmailTemplateByName doesn't contain 404..
+  return apiCall(client, client.emailTemplates.update, [ { name: name }, tpl ]).then(() => true);
+};
+
+const updateAllEmailTemplates = function(progress, client, files) {
+  progress.log('Updating email templates...');
+
+  const promises = constants.EMAIL_TEMPLATES.map(name =>
+    updateEmailTemplateByName(progress, client, files, name)
+  );
+
+  return Promise.all(promises);
+};
+
+module.exports = {
+  getEmailTemplateByName: getEmailTemplateByName,
+  getEmailTemplateObject: getEmailTemplateObject,
+  updateEmailTemplateByName: updateEmailTemplateByName,
+  updateAllEmailTemplates: updateAllEmailTemplates
+};

--- a/src/auth0/emailTemplates.js
+++ b/src/auth0/emailTemplates.js
@@ -61,7 +61,7 @@ const updateEmailTemplateByName = function(progress, client, files, name) {
 const updateAllEmailTemplates = function(progress, client, files) {
   progress.log('Updating email templates...');
 
-  const promises = constants.EMAIL_TEMPLATES.map(name =>
+  const promises = constants.EMAIL_TEMPLATE_NAMES.map(name =>
     updateEmailTemplateByName(progress, client, files, name)
   );
 

--- a/src/auth0/index.js
+++ b/src/auth0/index.js
@@ -5,6 +5,7 @@ const clients = require('./clients');
 const ruleConfigs = require('./ruleConfigs');
 const resourceServers = require('./resourceServers');
 const emailTemplates = require('./emailTemplates');
+const emailProviders = require('./emailProviders');
 
 module.exports = {
   /* Connection and database operations */
@@ -35,5 +36,8 @@ module.exports = {
   updateGuardianMultifactorPage: pages.updateGuardianMultifactorPage,
 
   /* Email template operations */
-  updateAllEmailTemplates: emailTemplates.updateAllEmailTemplates
+  updateAllEmailTemplates: emailTemplates.updateAllEmailTemplates,
+
+  /* Email provider operations */
+  updateEmailProvider: emailProviders.updateEmailProvider
 };

--- a/src/auth0/index.js
+++ b/src/auth0/index.js
@@ -4,6 +4,7 @@ const connections = require('./connections');
 const clients = require('./clients');
 const ruleConfigs = require('./ruleConfigs');
 const resourceServers = require('./resourceServers');
+const emailTemplates = require('./emailTemplates');
 
 module.exports = {
   /* Connection and database operations */
@@ -31,5 +32,8 @@ module.exports = {
   updateErrorPage: pages.updateErrorPage,
   updatePasswordResetPage: pages.updatePasswordResetPage,
   updateLoginPage: pages.updateLoginPage,
-  updateGuardianMultifactorPage: pages.updateGuardianMultifactorPage
+  updateGuardianMultifactorPage: pages.updateGuardianMultifactorPage,
+
+  /* Email template operations */
+  updateAllEmailTemplates: emailTemplates.updateAllEmailTemplates
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -88,3 +88,7 @@ constants.EMAIL_TEMPLATE_NAMES = [
 constants.EMAIL_TEMPLATE_FILENAMES = _.flatMap(constants.EMAIL_TEMPLATE_NAMES, name => [ name + '.html', name + '.json' ]);
 
 constants.EMAIL_TEMPLATES_DIRECTORY = 'email-templates';
+
+constants.EMAIL_PROVIDER_NAME = 'default';
+constants.EMAIL_PROVIDER_FILENAME = constants.EMAIL_PROVIDER_NAME + '.json';
+constants.EMAIL_PROVIDERS_DIRECTORY = 'email-providers';

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,7 @@
 const constants = module.exports = { }; // eslint-disable-line no-multi-assign
+
+const _ = require('lodash');
+
 constants.RULES_DIRECTORY = 'rules';
 constants.RULES_STAGES = [
   'login_success'
@@ -69,7 +72,8 @@ constants.EMAIL_TEMPLATE_ENROLLMENT_EMAIL = 'enrollment_email';
 constants.EMAIL_TEMPLATE_CHANGE_PASSWORD = 'change_password';
 constants.EMAIL_TEMPLATE_PASSWORD_RESET = 'password_reset';
 constants.EMAIL_TEMPLATE_MFA_OOB_CODE = 'mfa_oob_code';
-constants.EMAIL_TEMPLATES = [
+
+constants.EMAIL_TEMPLATE_NAMES = [
   constants.EMAIL_TEMPLATE_VERIFY_EMAIL,
   constants.EMAIL_TEMPLATE_RESET_EMAIL,
   constants.EMAIL_TEMPLATE_WELCOME_EMAIL,
@@ -80,3 +84,7 @@ constants.EMAIL_TEMPLATES = [
   constants.EMAIL_TEMPLATE_PASSWORD_RESET,
   constants.EMAIL_TEMPLATE_MFA_OOB_CODE
 ];
+
+constants.EMAIL_TEMPLATE_FILENAMES = _.flatMap(constants.EMAIL_TEMPLATE_NAMES, name => [ name + '.html', name + '.json' ]);
+
+constants.EMAIL_TEMPLATES_DIRECTORY = 'email-templates';

--- a/src/constants.js
+++ b/src/constants.js
@@ -52,6 +52,8 @@ constants.DATABASE_SCRIPTS_IMPORT = [
   'login'
 ];
 
+constants.DATABASE_STRATEGY_AUTH0 = 'auth0';
+
 constants.RESOURCE_SERVERS_DIRECTORY = 'resource-servers';
 constants.RESOURCE_SERVERS_CLIENT_NAME = 'resourceServers';
 constants.RESOURCE_SERVERS_MANAGEMENT_API_NAME = 'Auth0 Management API';

--- a/src/constants.js
+++ b/src/constants.js
@@ -59,3 +59,24 @@ constants.CLIENTS_CLIENT_NAME = 'clients';
 constants.CLIENTS_CLIENT_ID_NAME = 'client_id';
 
 constants.CONCURRENT_CALLS = 5;
+
+constants.EMAIL_TEMPLATE_VERIFY_EMAIL = 'verify_email';
+constants.EMAIL_TEMPLATE_RESET_EMAIL = 'reset_email';
+constants.EMAIL_TEMPLATE_WELCOME_EMAIL = 'welcome_email';
+constants.EMAIL_TEMPLATE_BLOCKED_ACCOUNT = 'blocked_account';
+constants.EMAIL_TEMPLATE_STOLEN_CREDENTIALS = 'stolen_credentials';
+constants.EMAIL_TEMPLATE_ENROLLMENT_EMAIL = 'enrollment_email';
+constants.EMAIL_TEMPLATE_CHANGE_PASSWORD = 'change_password';
+constants.EMAIL_TEMPLATE_PASSWORD_RESET = 'password_reset';
+constants.EMAIL_TEMPLATE_MFA_OOB_CODE = 'mfa_oob_code';
+constants.EMAIL_TEMPLATES = [
+  constants.EMAIL_TEMPLATE_VERIFY_EMAIL,
+  constants.EMAIL_TEMPLATE_RESET_EMAIL,
+  constants.EMAIL_TEMPLATE_WELCOME_EMAIL,
+  constants.EMAIL_TEMPLATE_BLOCKED_ACCOUNT,
+  constants.EMAIL_TEMPLATE_STOLEN_CREDENTIALS,
+  constants.EMAIL_TEMPLATE_ENROLLMENT_EMAIL,
+  constants.EMAIL_TEMPLATE_CHANGE_PASSWORD,
+  constants.EMAIL_TEMPLATE_PASSWORD_RESET,
+  constants.EMAIL_TEMPLATE_MFA_OOB_CODE
+];

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -100,6 +100,11 @@ module.exports = function(progressData, context, client, storage, config, slackT
       return auth0.updateClients(progress, client);
     })
     .then(function() {
+      // Update email provider _before_ templates, since a non-empty 'from' address in
+      // a template requires an enabled email provider.
+      return auth0.updateEmailProvider(progress, client, context.emailProviders);
+    })
+    .then(function() {
       return auth0.updateAllEmailTemplates(progress, client, context.emailTemplates);
     })
     .then(function() {

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -55,7 +55,8 @@ module.exports = function(progressData, context, client, storage, config, slackT
         rules: context.rules,
         ruleConfigs: context.ruleConfigs,
         pages: context.pages,
-        databases: context.databases
+        databases: context.databases,
+        emailTemplates: context.emailTemplates
       }, utils.checksumReplacer([ 'htmlFile', 'scriptFile' ]));
       progress.log('Assets: ' + assets, null, 2);
     })
@@ -97,6 +98,9 @@ module.exports = function(progressData, context, client, storage, config, slackT
     })
     .then(function() {
       return auth0.updateClients(progress, client);
+    })
+    .then(function() {
+      return auth0.updateAllEmailTemplates(progress, client, context.emailTemplates);
     })
     .then(function() {
       return progress.log('Done.');

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,6 +84,11 @@ module.exports.unifyDatabases = function(data, mappings) {
       scripts: unifyScripts(item.scripts, mappings)
     };
 
+    if (item.configurationFile) {
+      connection.configuration = module.exports.parseJsonFile(item.configurationFileName,
+        item.configurationFile, mappings);
+    }
+
     converted.push(connection);
   });
 

--- a/tests/auth0/auth0.tests.js
+++ b/tests/auth0/auth0.tests.js
@@ -1,0 +1,8 @@
+const expect = require('expect');
+const auth0 = require('../../src/auth0');
+
+describe('#auth0', () => {
+  it('exposes function for updating all email templates', () => {
+    expect(auth0.updateAllEmailTemplates).toBeA(Function);
+  });
+});

--- a/tests/auth0/connections.tests.js
+++ b/tests/auth0/connections.tests.js
@@ -10,7 +10,14 @@ describe('#connections', () => {
 
   const existingConnections = [
     { id: 456, name: 'Username-Password' },
-    { id: 123, name: 'My-Other-Custom-DB' },
+    { id: 123,
+      name: 'My-Other-Custom-DB',
+      options: {
+        passwordPolicy: 'low',
+        requires_username: false
+      },
+      metadata: { meta: true }
+    },
     { id: 666, name: 'Bad-Connection' },
     { id: 789, name: 'My-Custom-DB', options: { import_mode: true } }
   ];
@@ -51,6 +58,14 @@ describe('#connections', () => {
       },
       get_user: {
         scriptFile: 'function get_user() { }'
+      }
+    },
+    configuration: {
+      options: {
+        requires_username: true
+      },
+      metadata: {
+        setting: 'test'
       }
     }
   };
@@ -117,6 +132,26 @@ describe('#connections', () => {
           expect(updatePayloads[0].options.customScripts.delete).toEqual('function delete() { }');
           expect(updatePayloads[0].options.customScripts.get_user).toEqual('function get_user() { }');
           expect(updatePayloads[0].options.customScripts.change_email).toEqual('function change_email() { }');
+          done();
+        });
+    });
+
+    it('should include custom options in the update', (done) => {
+      connections.updateDatabase(progress, auth0, existingConnections, database)
+        .then(() => {
+          expect(updatePayloads[0].options).toExist();
+          expect(updatePayloads[0].options.requires_username).toEqual(true);
+          expect(updatePayloads[0].options.passwordPolicy).toEqual('low');
+          done();
+        });
+    });
+
+    it('should include custom metadata in the update', (done) => {
+      connections.updateDatabase(progress, auth0, existingConnections, database)
+        .then(() => {
+          expect(updatePayloads[0].metadata).toExist();
+          expect(updatePayloads[0].metadata.setting).toEqual('test');
+          expect(updatePayloads[0].metadata.meta).toEqual(true);
           done();
         });
     });

--- a/tests/auth0/emailProviders.tests.js
+++ b/tests/auth0/emailProviders.tests.js
@@ -55,9 +55,11 @@ describe('#emailProviders', () => {
 
     it('should update the provider correctly', (done) => {
       let payload = null;
+      let params = null;
       const auth0 = {
         emailProvider: {
-          update(data) {
+          update(paramsObj, data) {
+            params = paramsObj;
             payload = data;
             return Promise.resolve(true);
           }
@@ -74,6 +76,7 @@ describe('#emailProviders', () => {
       emailProviders.updateEmailProvider(progress, auth0, files)
         .then(function(result) {
           expect(result).toEqual(true);
+          expect(params).toEqual({});
           expect(payload.name).toEqual('smtp');
           done();
         });

--- a/tests/auth0/emailProviders.tests.js
+++ b/tests/auth0/emailProviders.tests.js
@@ -81,5 +81,34 @@ describe('#emailProviders', () => {
           done();
         });
     });
+
+    it('should configure (create) the provider if it doesn\'t exist', (done) => {
+      let payload = null;
+      const auth0 = {
+        emailProvider: {
+          update() {
+            return Promise.reject({ statusCode: 404 });
+          },
+          configure(data) {
+            payload = data;
+            return Promise.resolve(true);
+          }
+        }
+      };
+
+      const files = {
+        default: {
+          name: 'default',
+          configFile: '{"name":"smtp"}'
+        }
+      };
+
+      emailProviders.updateEmailProvider(progress, auth0, files)
+        .then(function(result) {
+          expect(result).toEqual(true);
+          expect(payload.name).toEqual('smtp');
+          done();
+        });
+    });
   });
 });

--- a/tests/auth0/emailProviders.tests.js
+++ b/tests/auth0/emailProviders.tests.js
@@ -1,0 +1,82 @@
+const expect = require('expect');
+// const Promise = require('bluebird');
+
+const emailProviders = require('../../src/auth0/emailProviders');
+// const constants = require('../../src/constants');
+
+describe('#emailProviders', () => {
+  let progress = null;
+
+  beforeEach(() => {
+    progress = {
+      log: () => null
+    };
+  });
+
+  describe('#getEmailProviderObject', () => {
+    it('should return null if there is no file', () => {
+      expect(emailProviders.getEmailProviderObject({ })).toNotExist();
+    });
+
+    it('should return null if there is no \'default\' file', () => {
+      expect(emailProviders.getEmailProviderObject({ other: {} })).toNotExist();
+    });
+
+    it('should find the default provider', () => {
+      const files = {
+        default: {
+          configFile: '{"name":"smtp"}'
+        }
+      };
+      const object = emailProviders.getEmailProviderObject(files);
+      expect(object.name).toEqual('smtp');
+    });
+
+    it('should replace mappings', () => {
+      const files = {
+        default: {
+          configFile: '{"name":@@name@@}'
+        }
+      };
+      const mappings = { name: 'smtp' };
+      const object = emailProviders.getEmailProviderObject(files, mappings);
+      expect(object.name).toEqual('smtp');
+    });
+  });
+
+  describe('#updateEmailProvider', () => {
+    it('should continue if \'default\' file does not exist', (done) => {
+      emailProviders.updateEmailProvider(progress, null, { })
+        .then(function(result) {
+          expect(result).toExist();
+          done();
+        });
+    });
+
+    it('should update the provider correctly', (done) => {
+      let payload = null;
+      const auth0 = {
+        emailProvider: {
+          update(data) {
+            payload = data;
+            return Promise.resolve(true);
+          }
+        }
+      };
+
+      const files = {
+        default: {
+          name: 'default',
+          configFile: '{"name":"smtp"}'
+        }
+      };
+
+      emailProviders.updateEmailProvider(progress, auth0, files)
+        .then(function(result) {
+          expect(result).toEqual(true);
+          expect(payload.name).toEqual('smtp');
+          done();
+        });
+    });
+  });
+});

--- a/tests/auth0/emailTemplates.tests.js
+++ b/tests/auth0/emailTemplates.tests.js
@@ -1,0 +1,151 @@
+const expect = require('expect');
+const Promise = require('bluebird');
+
+const emailTemplates = require('../../src/auth0/emailTemplates');
+const constants = require('../../src/constants');
+
+describe('#emailTemplates', () => {
+  let progress = null;
+  const files = {
+    verify_email: {
+      htmlFile: 'this is verify_email'
+    },
+    verify_email_with_metadata: {
+      htmlFile: 'this is verify_email_with_template',
+      metadata: true,
+      metadataFile: '{ "enabled": "foo" }'
+    },
+    verify_email_with_mapping: {
+      htmlFile: 'this is verify_email_with_mapping',
+      metadata: true,
+      metadataFile: '{ "enabled": ##iz_enabled## }'
+    }
+  };
+
+  beforeEach(() => {
+    progress = {
+      log: () => null
+    };
+  });
+
+  describe('#getEmailTemplateByName', () => {
+    it('should return cached template', (done) => {
+      progress.emailTemplates = { verify_email: { body: 'cached' } };
+
+      emailTemplates.getEmailTemplateByName(progress, null, 'verify_email')
+        .then((templateObject) => {
+          expect(templateObject.body).toEqual('cached');
+          done();
+        });
+    });
+
+    it('should call auth0 and get a template', (done) => {
+      const auth0 = {
+        emailTemplates: {
+          get(params) {
+            return Promise.resolve(
+              {
+                template: params.name,
+                body: '<html></html>'
+              }
+            );
+          }
+        }
+      };
+
+      emailTemplates.getEmailTemplateByName(progress, auth0, 'verify_email')
+        .then((templateObject) => {
+          expect(templateObject.template).toEqual('verify_email');
+          expect(templateObject.body).toEqual('<html></html>');
+          expect(progress.emailTemplates.verify_email).toExist();
+          done();
+        });
+    });
+  });
+
+  describe('#getEmailTemplateObject', () => {
+    it('should return null if page not found', () => {
+      expect(emailTemplates.getEmailTemplateObject({ }, 'foo')).toNotExist();
+    });
+
+    it('should return the correct template', () => {
+      const tpl = emailTemplates.getEmailTemplateObject(files, 'verify_email');
+      expect(tpl).toExist();
+      expect(tpl.body).toEqual('this is verify_email');
+    });
+
+    it('should default to disabled', () => {
+      const tpl = emailTemplates.getEmailTemplateObject(files, 'verify_email');
+      expect(tpl).toExist();
+      expect(tpl.enabled).toEqual(false);
+    });
+
+    it('should read enabled status from metadata', () => {
+      const tpl = emailTemplates.getEmailTemplateObject(files, 'verify_email_with_metadata');
+      expect(tpl).toExist();
+      expect(tpl.enabled).toEqual('foo');
+    });
+
+    it('should apply mappings', () => {
+      const mappings = { iz_enabled: false };
+      const tpl = emailTemplates.getEmailTemplateObject(files, 'verify_email_with_mapping', mappings);
+      expect(tpl).toExist();
+      expect(tpl.enabled).toEqual(false);
+    });
+  });
+
+  describe('#updateEmailTemplateByName', () => {
+    it('should continue if file does not exist', (done) => {
+      emailTemplates.updateEmailTemplateByName(progress, null, { }, 'verify_email')
+        .then(function(result) {
+          expect(result).toExist();
+          done();
+        });
+    });
+
+    it('should update template correctly', (done) => {
+      let payload = null;
+      let paramsObj = null;
+      const auth0 = {
+        emailTemplates: {
+          update(params, data) {
+            paramsObj = params;
+            payload = data;
+            return Promise.resolve(true);
+          }
+        }
+      };
+
+      emailTemplates.updateEmailTemplateByName(progress, auth0, files, 'verify_email')
+        .then(function() {
+          expect(paramsObj.name).toEqual('verify_email');
+          expect(payload.body).toEqual('this is verify_email');
+          done();
+        });
+    });
+  });
+
+  describe('#updateAllEmailTemplates', () => {
+    let callCount = 0;
+    const myFiles = {};
+    constants.EMAIL_TEMPLATES.forEach((name) => {
+      myFiles[name] = { htmlFile: '<html>', metadata: true, metadataFile: '{"enabled":true}' };
+    });
+    const auth0 = {
+      emailTemplates: {
+        update: function() {
+          callCount += 1;
+          return Promise.resolve(true);
+        }
+      }
+    };
+    it('should update all email template types', (done) => {
+      emailTemplates.updateAllEmailTemplates(progress, auth0, myFiles)
+        .then(function(result) {
+          expect(result).toExist();
+          expect(callCount).toEqual(constants.EMAIL_TEMPLATES.length);
+          done();
+        });
+    });
+  });
+});

--- a/tests/auth0/emailTemplates.tests.js
+++ b/tests/auth0/emailTemplates.tests.js
@@ -29,7 +29,7 @@ describe('#emailTemplates', () => {
   });
 
   describe('#getEmailTemplateObject', () => {
-    it('should return null if page not found', () => {
+    it('should return null if template not found', () => {
       expect(emailTemplates.getEmailTemplateObject({ }, 'foo')).toNotExist();
     });
 

--- a/tests/auth0/emailTemplates.tests.js
+++ b/tests/auth0/emailTemplates.tests.js
@@ -128,7 +128,7 @@ describe('#emailTemplates', () => {
   describe('#updateAllEmailTemplates', () => {
     let callCount = 0;
     const myFiles = {};
-    constants.EMAIL_TEMPLATES.forEach((name) => {
+    constants.EMAIL_TEMPLATE_NAMES.forEach((name) => {
       myFiles[name] = { htmlFile: '<html>', metadata: true, metadataFile: '{"enabled":true}' };
     });
     const auth0 = {
@@ -143,7 +143,7 @@ describe('#emailTemplates', () => {
       emailTemplates.updateAllEmailTemplates(progress, auth0, myFiles)
         .then(function(result) {
           expect(result).toExist();
-          expect(callCount).toEqual(constants.EMAIL_TEMPLATES.length);
+          expect(callCount).toEqual(constants.EMAIL_TEMPLATE_NAMES.length);
           done();
         });
     });

--- a/tests/auth0/emailTemplates.tests.js
+++ b/tests/auth0/emailTemplates.tests.js
@@ -57,6 +57,20 @@ describe('#emailTemplates', () => {
       expect(tpl).toExist();
       expect(tpl.enabled).toEqual(false);
     });
+
+    it('should ignore \'body\' and \'template\' in metadata, since they come from the HTML file and the template name, respectively', () => {
+      const myFiles = {
+        verify_email: {
+          htmlFile: '<html>real</html>',
+          metadata: true,
+          metadataFile: '{"template":"foo","body":"<html>fake</html>"}'
+        }
+      };
+      const tpl = emailTemplates.getEmailTemplateObject(myFiles, 'verify_email', {});
+      expect(tpl).toExist();
+      expect(tpl.body).toEqual('<html>real</html>');
+      expect(tpl.template).toEqual('verify_email');
+    });
   });
 
   describe('#updateEmailTemplateByName', () => {

--- a/tests/auth0/emailTemplates.tests.js
+++ b/tests/auth0/emailTemplates.tests.js
@@ -102,6 +102,27 @@ describe('#emailTemplates', () => {
           done();
         });
     });
+
+    it('should create template if it doesn\'t exist', (done) => {
+      let payload = null;
+      const auth0 = {
+        emailTemplates: {
+          update() {
+            return Promise.reject({ statusCode: 404 });
+          },
+          create(data) {
+            payload = data;
+            return Promise.resolve(true);
+          }
+        }
+      };
+
+      emailTemplates.updateEmailTemplateByName(progress, auth0, files, 'verify_email')
+        .then(function() {
+          expect(payload.body).toEqual('this is verify_email');
+          done();
+        });
+    });
   });
 
   describe('#updateAllEmailTemplates', () => {

--- a/tests/auth0/emailTemplates.tests.js
+++ b/tests/auth0/emailTemplates.tests.js
@@ -28,41 +28,6 @@ describe('#emailTemplates', () => {
     };
   });
 
-  describe('#getEmailTemplateByName', () => {
-    it('should return cached template', (done) => {
-      progress.emailTemplates = { verify_email: { body: 'cached' } };
-
-      emailTemplates.getEmailTemplateByName(progress, null, 'verify_email')
-        .then((templateObject) => {
-          expect(templateObject.body).toEqual('cached');
-          done();
-        });
-    });
-
-    it('should call auth0 and get a template', (done) => {
-      const auth0 = {
-        emailTemplates: {
-          get(params) {
-            return Promise.resolve(
-              {
-                template: params.name,
-                body: '<html></html>'
-              }
-            );
-          }
-        }
-      };
-
-      emailTemplates.getEmailTemplateByName(progress, auth0, 'verify_email')
-        .then((templateObject) => {
-          expect(templateObject.template).toEqual('verify_email');
-          expect(templateObject.body).toEqual('<html></html>');
-          expect(progress.emailTemplates.verify_email).toExist();
-          done();
-        });
-    });
-  });
-
   describe('#getEmailTemplateObject', () => {
     it('should return null if page not found', () => {
       expect(emailTemplates.getEmailTemplateObject({ }, 'foo')).toNotExist();

--- a/tests/constants.tests.js
+++ b/tests/constants.tests.js
@@ -19,4 +19,16 @@ describe('#constants', () => {
   it('should have email templates directory', () => {
     expect(tools.constants.EMAIL_TEMPLATES_DIRECTORY).toEqual('email-templates');
   });
+
+  it('should have email providers directory', () => {
+    expect(tools.constants.EMAIL_PROVIDERS_DIRECTORY).toEqual('email-providers');
+  });
+
+  it('should have name of default email provider', () => {
+    expect(tools.constants.EMAIL_PROVIDER_NAME).toEqual('default');
+  });
+
+  it('should have file name of default email provider', () => {
+    expect(tools.constants.EMAIL_PROVIDER_FILENAME).toEqual('default.json');
+  });
 });

--- a/tests/constants.tests.js
+++ b/tests/constants.tests.js
@@ -6,4 +6,8 @@ describe('#constants', () => {
     expect(tools.constants.PAGE_NAMES).toExist();
     expect(tools.constants.RULES_STAGES).toInclude('login_success');
   });
+
+  it('should have email template names', () => {
+    expect(tools.constants.EMAIL_TEMPLATES.length).toBeGreaterThan(0);
+  });
 });

--- a/tests/constants.tests.js
+++ b/tests/constants.tests.js
@@ -8,6 +8,15 @@ describe('#constants', () => {
   });
 
   it('should have email template names', () => {
-    expect(tools.constants.EMAIL_TEMPLATES.length).toBeGreaterThan(0);
+    expect(tools.constants.EMAIL_TEMPLATE_NAMES.length).toBeGreaterThan(0);
+  });
+
+  it('should have email template file names', () => {
+    expect(tools.constants.EMAIL_TEMPLATE_FILENAMES).toContain('verify_email.html');
+    expect(tools.constants.EMAIL_TEMPLATE_FILENAMES).toContain('verify_email.json');
+  });
+
+  it('should have email templates directory', () => {
+    expect(tools.constants.EMAIL_TEMPLATES_DIRECTORY).toEqual('email-templates');
   });
 });

--- a/tests/deploy.tests.js
+++ b/tests/deploy.tests.js
@@ -65,7 +65,7 @@ describe('#deploy', () => {
     const progressData = {};
     const client = {
       emailProvider: {
-        update(config) {
+        update(_, config) {
           providerConfig = config;
           operations.push('provider');
           return Promise.resolve(true);

--- a/tests/deploy.tests.js
+++ b/tests/deploy.tests.js
@@ -1,0 +1,50 @@
+const expect = require('expect');
+const deploy = require('../src/deploy');
+const Promise = require('bluebird');
+
+describe('#deploy', () => {
+  const context = {
+    init() {
+      return Promise.resolve(true);
+    },
+    emailTemplates: {
+      verify_email: {
+        htmlFile: '<html></html>'
+      }
+    },
+    pages: {},
+    databases: [],
+    clients: {},
+    resourceServers: {},
+    configurables: {},
+    rules: {}
+  };
+
+  const storage = {
+    read: () => Promise.resolve({}),
+    write: () => Promise.resolve({})
+  };
+
+  it('updates email templates', (done) => {
+    const updatedTemplates = [];
+    // function(progressData, context, client, storage, config, slackTemplate) {
+    const progressData = {};
+    const client = {
+      emailTemplates: {
+        update(paramsObj) {
+          updatedTemplates.push(paramsObj.name);
+          return Promise.resolve(true);
+        }
+      },
+      rules: {
+        getAll: () => Promise.resolve([])
+      }
+    };
+    const config = () => {};
+    const slackTemplate = {};
+    deploy(progressData, context, client, storage, config, slackTemplate).then(() => {
+      expect(updatedTemplates).toEqual([ 'verify_email' ]);
+      done();
+    });
+  });
+});

--- a/tests/deploy.tests.js
+++ b/tests/deploy.tests.js
@@ -9,7 +9,8 @@ describe('#deploy', () => {
     },
     emailTemplates: {
       verify_email: {
-        htmlFile: '<html></html>'
+        htmlFile: '<html></html>',
+        name: 'verify_email'
       }
     },
     pages: {},
@@ -17,7 +18,13 @@ describe('#deploy', () => {
     clients: {},
     resourceServers: {},
     configurables: {},
-    rules: {}
+    rules: {},
+    emailProviders: {
+      default: {
+        configFile: '{"name":"smtp"}',
+        name: 'default'
+      }
+    }
   };
 
   const storage = {
@@ -36,6 +43,9 @@ describe('#deploy', () => {
           return Promise.resolve(true);
         }
       },
+      emailProvider: {
+        update: () => Promise.resolve(true)
+      },
       rules: {
         getAll: () => Promise.resolve([])
       }
@@ -44,6 +54,38 @@ describe('#deploy', () => {
     const slackTemplate = {};
     deploy(progressData, context, client, storage, config, slackTemplate).then(() => {
       expect(updatedTemplates).toEqual([ 'verify_email' ]);
+      done();
+    });
+  });
+
+  it('updates email providers _before_ email templates', (done) => {
+    const operations = [];
+    let providerConfig = null;
+    // function(progressData, context, client, storage, config, slackTemplate) {
+    const progressData = {};
+    const client = {
+      emailProvider: {
+        update(config) {
+          providerConfig = config;
+          operations.push('provider');
+          return Promise.resolve(true);
+        }
+      },
+      emailTemplates: {
+        update() {
+          operations.push('template');
+          return Promise.resolve(true);
+        }
+      },
+      rules: {
+        getAll: () => Promise.resolve([])
+      }
+    };
+    const config = () => {};
+    const slackTemplate = {};
+    deploy(progressData, context, client, storage, config, slackTemplate).then(() => {
+      expect(providerConfig.name).toEqual('smtp');
+      expect(operations).toEqual([ 'provider', 'template' ]);
       done();
     });
   });

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -4,7 +4,7 @@ const utils = require('../src/utils');
 
 
 describe('#utils', function() {
-  it('should unify scripts', function(done) {
+  it('should unify database scripts', function(done) {
     const data = [ {
       name: 'database',
       scripts: [
@@ -41,6 +41,30 @@ describe('#utils', function() {
           metadataFile: '{"b":2}',
           scriptFile: 'console.log("goodbye");'
         }
+      }
+    } ];
+
+    expect(utils.unifyDatabases(data, mappings)).to.deep.equal(expectation);
+    done();
+  });
+
+  it('should read configuration when unifying database scripts', function(done) {
+    const data = [ {
+      name: 'database',
+      scripts: [],
+      configurationFile: '{"hello":@@hello@@}',
+      configurationFileName: 'configuration.json'
+    } ];
+
+    const mappings = {
+      hello: 'goodbye'
+    };
+
+    const expectation = [ {
+      name: 'database',
+      scripts: {},
+      configuration: {
+        hello: 'goodbye'
       }
     } ];
 


### PR DESCRIPTION
Apologies for the big PR, but I have been adding functionality to a fork for a customer project. Everything seems to be working, so I thought it'd be a good idea to get the functionality into the main repo.

This PR adds support for:

* Updating or creating e-mail templates.
* Update or configure the e-mail provider.
* Pass options and metadata when updating a connection.

If this gets merged, I have a matching PR for the auth0-deploy-cli repo.