### PR TITLE
Add support for AUTH0_ALLOW_DELETE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/clientGrants.js
+++ b/src/auth0/handlers/clientGrants.js
@@ -29,6 +29,10 @@ export default class ClientHandler extends DefaultHandler {
     });
   }
 
+  objString(item) {
+    return super.objString({ id: item.id, client_id: item.client_id, audience: item.audience });
+  }
+
   async getType() {
     if (this.existing) {
       return this.existing;
@@ -64,12 +68,6 @@ export default class ClientHandler extends DefaultHandler {
   // Run after clients are updated so we can convert client_id names to id's
   @order('60')
   async processChanges(assets) {
-    const { clientGrants } = assets;
-
-    // Do nothing if not set
-    if (!clientGrants || !clientGrants.length) return;
-
-    const changes = await this.calcChanges(assets);
-    await super.processChanges(assets, { ...changes });
+    await super.processChanges(assets);
   }
 }

--- a/src/auth0/handlers/clients.js
+++ b/src/auth0/handlers/clients.js
@@ -1,6 +1,4 @@
 import DefaultHandler from './default';
-import { dumpJSON } from '../../utils';
-import log from '../../logger';
 
 export const schema = {
   type: 'array',
@@ -28,16 +26,8 @@ export default class ClientHandler extends DefaultHandler {
     });
   }
 
-  didDelete(client) {
-    return super.didDelete({ name: client.name, client_id: client.client_id });
-  }
-
-  didCreate(client) {
-    return super.didCreate({ name: client.name, client_id: client.client_id });
-  }
-
-  didUpdate(client) {
-    return super.didUpdate({ name: client.name, client_id: client.client_id });
+  objString(item) {
+    return super.objString({ name: item.name, client_id: item.client_id });
   }
 
   async processChanges(assets) {
@@ -59,18 +49,6 @@ export default class ClientHandler extends DefaultHandler {
       create: create.filter(c => c.client_id !== currentClient),
       conflicts: conflicts.filter(c => c.client_id !== currentClient)
     };
-
-    // Don't delete clients unless told as you cannot recover client_id's if deleted.
-    const shouldDelete = this.config('AUTH0_ALLOW_CLIENT_DELETE') === 'true' || this.config('AUTH0_ALLOW_CLIENT_DELETE') === true;
-    if (!shouldDelete) {
-      if (changes.del.length > 0) {
-        log.warn(`Detected the following clients should be deleted.
-        Doing so will be prevent authentications using the client_id. You can force deletes by setting 'AUTH0_ALLOW_CLIENT_DELETE' to true in the config
-        \n${dumpJSON(changes.del.map(client => ({ name: client.name, client_id: client.client_id })), 2)})
-         `);
-      }
-      changes.del = [];
-    }
 
     await super.processChanges(assets, {
       ...changes

--- a/src/auth0/handlers/connections.js
+++ b/src/auth0/handlers/connections.js
@@ -1,6 +1,4 @@
 import DefaultHandler, { order } from './default';
-import { dumpJSON } from '../../utils';
-import log from '../../logger';
 
 export const schema = {
   type: 'array',
@@ -28,16 +26,8 @@ export default class ConnectionsHandler extends DefaultHandler {
     });
   }
 
-  didDelete(connection) {
-    return super.didDelete({ name: connection.name, id: connection.id });
-  }
-
-  didCreate(connection) {
-    return super.didCreate({ name: connection.name, id: connection.id });
-  }
-
-  didUpdate(connection) {
-    return super.didUpdate({ name: connection.name, id: connection.id });
+  objString(connection) {
+    return super.objString({ name: connection.name, id: connection.id });
   }
 
   async getType() {
@@ -80,20 +70,6 @@ export default class ConnectionsHandler extends DefaultHandler {
     // Do nothing if not set
     if (!connections || !connections.length) return;
 
-    const changes = await this.calcChanges(assets);
-
-    // Don't delete connections unless told as it's destructive and will delete all associated users
-    const shouldDelete = this.config('AUTH0_ALLOW_CONNECTION_DELETE') === 'true' || this.config('AUTH0_ALLOW_CONNECTION_DELETE') === true;
-    if (!shouldDelete) {
-      if (changes.del.length > 0) {
-        log.warn(`Detected the following connections should be deleted.
-        Doing so will be delete all the associated users. You can force deletes by setting 'AUTH0_ALLOW_CONNECTION_DELETE' to true in the config
-        \n${dumpJSON(changes.del.map(db => ({ name: db.name, id: db.id })), 2)})
-         `);
-      }
-      changes.del = [];
-    }
-
-    await super.processChanges(assets, { ...changes });
+    await super.processChanges(assets);
   }
 }

--- a/src/auth0/handlers/databases.js
+++ b/src/auth0/handlers/databases.js
@@ -1,7 +1,5 @@
 import DefaultHandler, { order } from './default';
 import constants from '../../constants';
-import { dumpJSON } from '../../utils';
-import log from '../../logger';
 
 export const schema = {
   type: 'array',
@@ -37,16 +35,8 @@ export default class DatabaseHandler extends DefaultHandler {
     });
   }
 
-  didDelete(db) {
-    return super.didDelete({ name: db.name, id: db.id });
-  }
-
-  didCreate(db) {
-    return super.didCreate({ name: db.name, id: db.id });
-  }
-
-  didUpdate(db) {
-    return super.didUpdate({ name: db.name, id: db.id });
+  objString(db) {
+    return super.objString({ name: db.name, id: db.id });
   }
 
   getClientFN(fn) {
@@ -91,20 +81,6 @@ export default class DatabaseHandler extends DefaultHandler {
     // Do nothing if not set
     if (!databases || !databases.length) return;
 
-    const changes = await this.calcChanges(assets);
-
-    // Don't delete databases unless told as it's destructive and will delete all associated users
-    const shouldDelete = this.config('AUTH0_ALLOW_CONNECTION_DELETE') === 'true' || this.config('AUTH0_ALLOW_CONNECTION_DELETE') === true;
-    if (!shouldDelete) {
-      if (changes.del.length > 0) {
-        log.warn(`Detected the following database connections should be deleted.
-        Doing so will be delete all the associated users. You can force deletes by setting 'AUTH0_ALLOW_CONNECTION_DELETE' to true in the config
-        \n${dumpJSON(changes.del.map(db => ({ name: db.name, id: db.id })), 2)})
-         `);
-      }
-      changes.del = [];
-    }
-
-    await super.processChanges(assets, { ...changes });
+    await super.processChanges(assets);
   }
 }

--- a/src/auth0/handlers/pages.js
+++ b/src/auth0/handlers/pages.js
@@ -1,7 +1,5 @@
 import DefaultHandler from './default';
 import constants from '../../constants';
-import { dumpJSON } from '../../utils';
-import log from '../../logger';
 
 export const supportedPages = constants.PAGE_NAMES
   .filter(p => p.includes('.json'))
@@ -35,10 +33,8 @@ export default class PageHandler extends DefaultHandler {
     });
   }
 
-  didUpdate(page) {
-    const dump = { ...page };
-    delete dump.html;
-    log.info(`Updated [${this.type}]: ${dumpJSON(dump)}`);
+  objString(page) {
+    return super.objString({ name: page.name, enabled: page.enabled });
   }
 
   async updateLoginPage(page) {

--- a/src/auth0/handlers/resourceServers.js
+++ b/src/auth0/handlers/resourceServers.js
@@ -41,16 +41,8 @@ export default class ResourceServersHandler extends DefaultHandler {
     });
   }
 
-  didDelete(resourceServer) {
-    return super.didDelete({ name: resourceServer.name, identifier: resourceServer.identifier });
-  }
-
-  didCreate(resourceServer) {
-    return super.didCreate({ name: resourceServer.name, identifier: resourceServer.identifier });
-  }
-
-  didUpdate(resourceServer) {
-    return super.didUpdate({ name: resourceServer.name, identifier: resourceServer.identifier });
+  objString(resourceServer) {
+    return super.objString({ name: resourceServer.name, identifier: resourceServer.identifier });
   }
 
   async getType() {

--- a/src/auth0/handlers/rules.js
+++ b/src/auth0/handlers/rules.js
@@ -161,17 +161,11 @@ export default class RulesHandler extends DefaultHandler {
     if (!rules || !rules.length) return;
 
     // Figure out what needs to be updated vs created
-    const {
-      del,
-      update,
-      create,
-      reOrder,
-      conflicts
-    } = await this.calcChanges(assets);
+    const changes = await this.calcChanges(assets);
 
     // Temporally re-order rules with conflicting ordering
     await this.client.pool.addEachTask({
-      data: reOrder,
+      data: changes.reOrder,
       generator: rule => this.client.updateRule({ id: rule.id }, stripFields(rule, this.stripUpdateFields)).then(() => {
         const updated = {
           name: rule.name, stage: rule.stage, order: rule.order, id: rule.id
@@ -181,7 +175,10 @@ export default class RulesHandler extends DefaultHandler {
     }).promise();
 
     await super.processChanges(assets, {
-      del, create, update, conflicts
+      del: changes.del,
+      create: changes.create,
+      update: changes.update,
+      conflicts: changes.conflicts
     });
   }
 }

--- a/src/auth0/handlers/rulesConfigs.js
+++ b/src/auth0/handlers/rulesConfigs.js
@@ -28,16 +28,8 @@ export default class RulesConfigsHandler extends DefaultHandler {
     return this.client.rulesConfigs.getAll({ paginate: true });
   }
 
-  didDelete(config) {
-    return super.didDelete(config.key);
-  }
-
-  didCreate(config) {
-    return super.didCreate(config.key);
-  }
-
-  didUpdate(config) {
-    return super.didUpdate(config.key);
+  objString(item) {
+    return super.objString({ key: item.key });
   }
 
   async calcChanges(assets) {

--- a/tests/auth0/handlers/clientGrants.tests.js
+++ b/tests/auth0/handlers/clientGrants.tests.js
@@ -16,7 +16,8 @@ describe('#clientGrants handler', () => {
   };
 
   config.data = {
-    AUTH0_CLIENT_ID: 'client_id'
+    AUTH0_CLIENT_ID: 'client_id',
+    AUTH0_ALLOW_DELETE: true
   };
 
   describe('#clientGrants validate', () => {
@@ -180,7 +181,7 @@ describe('#clientGrants handler', () => {
       await stageFn.apply(handler, [ { clientGrants: data } ]);
     });
 
-    it('should delete client garant and create another one instead', async () => {
+    it('should delete client grant and create another one instead', async () => {
       const auth0 = {
         clientGrants: {
           create: (data) => {

--- a/tests/auth0/handlers/clients.tests.js
+++ b/tests/auth0/handlers/clients.tests.js
@@ -17,7 +17,7 @@ describe('#clients handler', () => {
 
   config.data = {
     AUTH0_CLIENT_ID: 'client_id',
-    AUTH0_ALLOW_CLIENT_DELETE: true
+    AUTH0_ALLOW_DELETE: true
   };
 
   describe('#clients validate', () => {
@@ -150,7 +150,7 @@ describe('#clients handler', () => {
     });
 
     it('should not remove client if it is not allowed by config', async () => {
-      config.data.AUTH0_ALLOW_CLIENT_DELETE = false;
+      config.data.AUTH0_ALLOW_DELETE = false;
       const auth0 = {
         clients: {
           create: () => Promise.resolve([]),

--- a/tests/auth0/handlers/connections.tests.js
+++ b/tests/auth0/handlers/connections.tests.js
@@ -17,7 +17,7 @@ describe('#connections handler', () => {
 
   config.data = {
     AUTH0_CLIENT_ID: 'client_id',
-    AUTH0_ALLOW_CONNECTION_DELETE: true
+    AUTH0_ALLOW_DELETE: true
   };
 
   describe('#connections validate', () => {
@@ -112,9 +112,10 @@ describe('#connections handler', () => {
           update: (params, data) => {
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
-            expect(data).to.be.an('object');
-            expect(data.options).to.be.an('object');
-            expect(data.options.passwordPolicy).to.equal('testPolicy');
+            expect(data).to.deep.equal({
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              options: { passwordPolicy: 'testPolicy' }
+            });
 
             return Promise.resolve({ ...params, ...data });
           },
@@ -122,7 +123,7 @@ describe('#connections handler', () => {
           getAll: () => [ { name: 'someConnection', id: 'con1', strategy: 'custom' } ]
         },
         clients: {
-          getAll: () => []
+          getAll: () => [ { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' } ]
         },
         pool
       };
@@ -133,7 +134,10 @@ describe('#connections handler', () => {
         {
           name: 'someConnection',
           strategy: 'custom',
-          options: { passwordPolicy: 'testPolicy' }
+          enabled_clients: [ 'client1' ],
+          options: {
+            passwordPolicy: 'testPolicy'
+          }
         }
       ];
 
@@ -176,7 +180,7 @@ describe('#connections handler', () => {
     });
 
     it('should not remove if it is not allowed by config', async () => {
-      config.data.AUTH0_ALLOW_CONNECTION_DELETE = false;
+      config.data.AUTH0_ALLOW_DELETE = false;
       const auth0 = {
         connections: {
           create: data => Promise.resolve(data),

--- a/tests/auth0/handlers/databases.tests.js
+++ b/tests/auth0/handlers/databases.tests.js
@@ -17,7 +17,7 @@ describe('#databases handler', () => {
 
   config.data = {
     AUTH0_CLIENT_ID: 'client_id',
-    AUTH0_ALLOW_CONNECTION_DELETE: true
+    AUTH0_ALLOW_DELETE: true
   };
 
   describe('#databases validate', () => {
@@ -105,9 +105,10 @@ describe('#databases handler', () => {
           update: (params, data) => {
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
-            expect(data).to.be.an('object');
-            expect(data.options).to.be.an('object');
-            expect(data.options.passwordPolicy).to.equal('testPolicy');
+            expect(data).to.deep.equal({
+              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              options: { passwordPolicy: 'testPolicy' }
+            });
 
             return Promise.resolve({ ...params, ...data });
           },
@@ -115,7 +116,7 @@ describe('#databases handler', () => {
           getAll: () => [ { name: 'someDatabase', id: 'con1', strategy: 'auth0' } ]
         },
         clients: {
-          getAll: () => []
+          getAll: () => [ { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' } ]
         },
         pool
       };
@@ -126,7 +127,8 @@ describe('#databases handler', () => {
         {
           name: 'someDatabase',
           strategy: 'auth0',
-          options: { passwordPolicy: 'testPolicy' }
+          options: { passwordPolicy: 'testPolicy' },
+          enabled_clients: [ 'client1' ]
         }
       ];
 
@@ -169,7 +171,7 @@ describe('#databases handler', () => {
     });
 
     it('should not remove if it is not allowed by config', async () => {
-      config.data.AUTH0_ALLOW_CONNECTION_DELETE = false;
+      config.data.AUTH0_ALLOW_DELETE = false;
       const auth0 = {
         connections: {
           create: data => Promise.resolve(data),

--- a/tests/auth0/handlers/resourceServers.tests.js
+++ b/tests/auth0/handlers/resourceServers.tests.js
@@ -11,9 +11,17 @@ const pool = {
 };
 
 describe('#resourceServers handler', () => {
+  const config = function(key) {
+    return config.data && config.data[key];
+  };
+
+  config.data = {
+    AUTH0_ALLOW_DELETE: true
+  };
+
   describe('#resourceServers validate', () => {
     it('should not allow same names', async () => {
-      const handler = new resourceServers.default({ client: {} });
+      const handler = new resourceServers.default({ client: {}, config });
       const stageFn = Object.getPrototypeOf(handler).validate;
       const data = [
         {
@@ -33,7 +41,7 @@ describe('#resourceServers handler', () => {
     });
 
     it('should not allow "Auth0 Management API" name', async () => {
-      const handler = new resourceServers.default({ client: {} });
+      const handler = new resourceServers.default({ client: {}, config });
       const stageFn = Object.getPrototypeOf(handler).validate;
       const data = [
         {
@@ -50,7 +58,7 @@ describe('#resourceServers handler', () => {
     });
 
     it('should pass validation', async () => {
-      const handler = new resourceServers.default({ client: {} });
+      const handler = new resourceServers.default({ client: {}, config });
       const stageFn = Object.getPrototypeOf(handler).validate;
       const data = [
         {
@@ -78,7 +86,7 @@ describe('#resourceServers handler', () => {
         pool
       };
 
-      const handler = new resourceServers.default({ client: auth0 });
+      const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI' } ] } ]);
@@ -94,7 +102,7 @@ describe('#resourceServers handler', () => {
         }
       };
 
-      const handler = new resourceServers.default({ client: auth0 });
+      const handler = new resourceServers.default({ client: auth0, config });
       const data = await handler.getType();
       expect(data).to.deep.equal([ { name: 'Company API', identifier: 'http://company.com/api' } ]);
     });
@@ -116,7 +124,7 @@ describe('#resourceServers handler', () => {
         pool
       };
 
-      const handler = new resourceServers.default({ client: auth0 });
+      const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI', identifier: 'some-api', scope: 'new:scope' } ] } ]);
@@ -137,7 +145,7 @@ describe('#resourceServers handler', () => {
         pool
       };
 
-      const handler = new resourceServers.default({ client: auth0 });
+      const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [ { resourceServers: [ {} ] } ]);
@@ -163,7 +171,7 @@ describe('#resourceServers handler', () => {
         pool
       };
 
-      const handler = new resourceServers.default({ client: auth0 });
+      const handler = new resourceServers.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
       const data = {
         resourceServers: [ { name: 'someAPI', identifier: 'some-api', scope: 'new:scope' } ],

--- a/tests/auth0/handlers/rules.tests.js
+++ b/tests/auth0/handlers/rules.tests.js
@@ -11,6 +11,14 @@ const pool = {
 };
 
 describe('#rules handler', () => {
+  const config = function(key) {
+    return config.data && config.data[key];
+  };
+
+  config.data = {
+    AUTH0_ALLOW_DELETE: true
+  };
+
   describe('#rules validate', () => {
     it('should not allow same names', async () => {
       const auth0 = {
@@ -19,7 +27,7 @@ describe('#rules handler', () => {
         }
       };
 
-      const handler = new rules.default({ client: auth0 });
+      const handler = new rules.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).validate;
       const data = [
         {
@@ -45,7 +53,7 @@ describe('#rules handler', () => {
         }
       };
 
-      const handler = new rules.default({ client: auth0 });
+      const handler = new rules.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).validate;
       const data = [
         {
@@ -76,7 +84,7 @@ describe('#rules handler', () => {
         }
       };
 
-      const handler = new rules.default({ client: auth0 });
+      const handler = new rules.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).validate;
       const data = [
         {
@@ -100,7 +108,7 @@ describe('#rules handler', () => {
         }
       };
 
-      const handler = new rules.default({ client: auth0 });
+      const handler = new rules.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).validate;
       const data = [
         {
@@ -129,7 +137,7 @@ describe('#rules handler', () => {
         pool
       };
 
-      const handler = new rules.default({ client: auth0 });
+      const handler = new rules.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [ { rules: [ { name: 'someRule', script: 'rule_script' } ] } ]);
@@ -151,7 +159,7 @@ describe('#rules handler', () => {
         rules: { getAll: () => rulesData }
       };
 
-      const handler = new rules.default({ client: auth0 });
+      const handler = new rules.default({ client: auth0, config });
       const data = await handler.getType();
       expect(data).to.deep.equal(rulesData);
     });
@@ -173,7 +181,7 @@ describe('#rules handler', () => {
         pool
       };
 
-      const handler = new rules.default({ client: auth0 });
+      const handler = new rules.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [ { rules: [ { name: 'someRule', script: 'new_script' } ] } ]);
@@ -194,7 +202,7 @@ describe('#rules handler', () => {
         pool
       };
 
-      const handler = new rules.default({ client: auth0 });
+      const handler = new rules.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [ { rules: [ {} ] } ]);
@@ -220,7 +228,7 @@ describe('#rules handler', () => {
         pool
       };
 
-      const handler = new rules.default({ client: auth0 });
+      const handler = new rules.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
       const data = {
         rules: [ { name: 'Rule1', script: 'new-rule-one-script' } ],


### PR DESCRIPTION
## ✏️ Changes

Ensure customers don't blow their tenant away by only deleting objects if config AUTH0_ALLOW_DELETE is true

## 🎯 Testing
Tests are updated.
   
✅This change has unit test coverage  
  
## 🚀 Deployment
  
✅ This can be deployed any time
