### PR TITLE
KEY-639: connection prop reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "3.0.10",
+  "version": "3.0.9",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/databases.js
+++ b/src/auth0/handlers/databases.js
@@ -41,6 +41,13 @@ export default class DatabaseHandler extends DefaultHandler {
 
   getClientFN(fn) {
     // Override this as a database is actually a connection but we are treating them as a different object
+    // If we going to update database, we need to get current options first
+    if (fn === this.functions.update) {
+      return (params, payload) => this.client.connections.get(params)
+        .then(connection => Object.assign({}, connection.options, payload.options))
+        .then(data => this.client.connections.update(params, data));
+    }
+
     return Reflect.get(this.client.connections, fn, this.client.connections);
   }
 

--- a/src/auth0/handlers/databases.js
+++ b/src/auth0/handlers/databases.js
@@ -44,8 +44,10 @@ export default class DatabaseHandler extends DefaultHandler {
     // If we going to update database, we need to get current options first
     if (fn === this.functions.update) {
       return (params, payload) => this.client.connections.get(params)
-        .then(connection => Object.assign({}, connection.options, payload.options))
-        .then(data => this.client.connections.update(params, data));
+        .then((connection) => {
+          payload.options = Object.assign({}, connection.options, payload.options);
+          return this.client.connections.update(params, payload);
+        });
     }
 
     return Reflect.get(this.client.connections, fn, this.client.connections);

--- a/tests/auth0/handlers/databases.tests.js
+++ b/tests/auth0/handlers/databases.tests.js
@@ -98,6 +98,11 @@ describe('#databases handler', () => {
     it('should update database', async () => {
       const auth0 = {
         connections: {
+          get: (params) => {
+            expect(params).to.be.an('object');
+            expect(params.id).to.equal('con1');
+            return Promise.resolve({ options: { someOldOption: true } });
+          },
           create: (data) => {
             expect(data).to.be.an('undefined');
             return Promise.resolve(data);
@@ -107,7 +112,7 @@ describe('#databases handler', () => {
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
               enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
-              options: { passwordPolicy: 'testPolicy' }
+              options: { passwordPolicy: 'testPolicy', someOldOption: true }
             });
 
             return Promise.resolve({ ...params, ...data });


### PR DESCRIPTION
## ✏️ Changes
API2 does not preserve old options properties on connection update. That's why we need to get old options object and merge it with new options before update.
  
## 🔗 References
  Jira: https://auth0team.atlassian.net/browse/KEY-639
  
## 🎯 Testing
✅ This change has been tested in a Webtask
✅ This change has unit test coverage
 