### PR TITLE
Do not force `enabled_clients` setting

### DIFF
--- a/src/auth0/handlers/databases.js
+++ b/src/auth0/handlers/databases.js
@@ -68,16 +68,20 @@ export default class DatabaseHandler extends DefaultHandler {
 
     // Convert enabled_clients by name to the id
     const clients = await this.client.clients.getAll({ paginate: true });
-    const formatted = databases.map(db => ({
-      ...db,
-      enabled_clients: [
-        ...(db.enabled_clients || []).map((name) => {
-          const found = clients.find(c => c.name === name);
-          if (found) return found.client_id;
-          return name;
-        })
-      ]
-    }));
+    const formatted = databases.map((db) => {
+      if (db.enabled_clients) {
+        return {
+          ...db,
+          enabled_clients: db.enabled_clients.map((name) => {
+            const found = clients.find(c => c.name === name);
+            if (found) return found.client_id;
+            return name;
+          })
+        };
+      }
+
+      return db;
+    });
 
     return super.calcChanges({ ...assets, databases: formatted });
   }


### PR DESCRIPTION
## ✏️ Changes
  Currently, we're forcing `enabled_clients` setting of the database connection to be updated, even if we do not have such setting in the assets (using `[]` by default). In these changes additional check is added to prevent updating `enabled_clients` if the list of enabled clients was not provided in the assets.
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1545937917007200?thread_ts=1544222234.120100&cid=C9170558S
  
## 🎯 Testing
✅ This change has been tested locally
🚫 This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  