### PR TITLE
Fix error due to import_mode required at wrong level

### DIFF
--- a/src/auth0/handlers/databases.js
+++ b/src/auth0/handlers/databases.js
@@ -18,10 +18,11 @@ export const schema = {
             },
             required: [ 'login', 'get_user' ]
           }
-        }
+        },
+        required: [ 'import_mode' ]
       }
     },
-    required: [ 'name', 'import_mode' ]
+    required: [ 'name' ]
   }
 };
 


### PR DESCRIPTION
## ✏️ Changes
Error in latest update with where import_mode is required. It's meant to be required under options. 

Fixes below error
```
{
        "keyword": "required",
        "dataPath": ".databases[0]",
        "schemaPath": "#/properties/databases/items/required",
        "params": {
            "missingProperty": ".import_mode"
        },
        "message": "should have required property '.import_mode'"
    }
```
