### PR TITLE
Fix email provider export

### DIFF
--- a/src/auth0/handlers/emailProvider.js
+++ b/src/auth0/handlers/emailProvider.js
@@ -2,6 +2,9 @@ import DefaultHandler from './default';
 
 export const schema = { type: 'object' };
 
+// The Management API requires the fields to be specified
+const defaultFields = [ 'name', 'enabled', 'credentials', 'settings', 'default_from_address' ];
+
 export default class EmailProviderHandler extends DefaultHandler {
   constructor(options) {
     super({
@@ -12,7 +15,7 @@ export default class EmailProviderHandler extends DefaultHandler {
 
   async getType() {
     try {
-      return await this.client.emailProvider.get();
+      return await this.client.emailProvider.get({ include_fields: true, fields: defaultFields });
     } catch (err) {
       if (err.statusCode === 404) return {};
       throw err;


### PR DESCRIPTION
## ✏️ Changes
 When exporting the emailProvider shows default values as we are not requesting the correct fields in the mgmt api.

This fixes https://github.com/auth0/auth0-deploy-cli/issues/84