### PR TITLE
Hide emailProvider sensitive data in logs during import

### DIFF
--- a/src/auth0/handlers/emailProvider.js
+++ b/src/auth0/handlers/emailProvider.js
@@ -22,6 +22,10 @@ export default class EmailProviderHandler extends DefaultHandler {
     }
   }
 
+  objString(provider) {
+    return super.objString({ name: provider.name, enabled: provider.enabled });
+  }
+
   async processChanges(assets) {
     const { emailProvider } = assets;
 


### PR DESCRIPTION
## ✏️ Changes
  
The recent updates to emailProvider is showing sensitive data in logs during import.

This fixes https://github.com/auth0/auth0-deploy-cli/issues/97 by only showing the name and enabled flag in logs.
