### PR TITLE
Ignore client grants for own client

### DIFF
--- a/src/auth0/handlers/clientGrants.js
+++ b/src/auth0/handlers/clientGrants.js
@@ -62,7 +62,13 @@ export default class ClientHandler extends DefaultHandler {
       if (found) grant.client_id = found.client_id;
       return grant;
     });
-    return super.calcChanges({ ...assets, clientGrants: formatted });
+
+    // Always filter out the client we are using to access Auth0 Management API
+    const currentClient = this.config('AUTH0_CLIENT_ID');
+
+    const filtered = formatted.filter(grant => grant.client_id !== currentClient);
+
+    return super.calcChanges({ ...assets, clientGrants: filtered });
   }
 
   // Run after clients are updated so we can convert client_id names to id's

--- a/tests/auth0/handlers/clientGrants.tests.js
+++ b/tests/auth0/handlers/clientGrants.tests.js
@@ -218,6 +218,45 @@ describe('#clientGrants handler', () => {
       await stageFn.apply(handler, [ { clientGrants: data } ]);
     });
 
+    it('should not delete nor create client grant for own client', async () => {
+      const auth0 = {
+        clientGrants: {
+          create: (params) => {
+            expect(params).to.be.an('undefined');
+
+            return Promise.resolve([]);
+          },
+          update: (params) => {
+            expect(params).to.be.an('undefined');
+
+            return Promise.resolve([]);
+          },
+          delete: (params) => {
+            expect(params).to.be.an('undefined');
+
+            return Promise.resolve([]);
+          },
+          getAll: () => [ { id: 'id', client_id: 'client_id', audience: 'audience' } ]
+        },
+        clients: {
+          getAll: () => []
+        },
+        pool
+      };
+
+      const handler = new clientGrants.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = [
+        {
+          name: 'someClientGrant',
+          client_id: 'client_id',
+          audience: 'audience'
+        }
+      ];
+
+      await stageFn.apply(handler, [ { clientGrants: data } ]);
+    });
+
     it('should delete all client grants', async () => {
       let removed = false;
       const auth0 = {


### PR DESCRIPTION
## ✏️ Changes
 Deploy extensions should not delete or update client grants of its own client. Currently, an attempt to update client grants of extension's client is leading to conflict error. Fixed by filtering client grants assets in similar way as we're doing for clients..
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1552574289164300
  
## 🎯 Testing 
✅ This change has been tested locally (with Bitbucket extension)
🚫 This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  