### PR TITLE
Allow extensions to remove rules/resourceServers

### DIFF
--- a/src/auth0/handlers/default.js
+++ b/src/auth0/handlers/default.js
@@ -122,7 +122,9 @@ export default class DefaultHandler {
 
     // Process Deleted
     if (del.length > 0) {
-      const shouldDelete = this.config('AUTH0_ALLOW_DELETE') === 'true' || this.config('AUTH0_ALLOW_DELETE') === true;
+      const allowDelete = this.config('AUTH0_ALLOW_DELETE') === 'true' || this.config('AUTH0_ALLOW_DELETE') === true;
+      const byExtension = this.config('EXTENSION_SECRET') && (this.type === 'rules' || this.type === 'resourceServers');
+      const shouldDelete = allowDelete || byExtension;
       if (!shouldDelete) {
         log.warn(`Detected the following ${this.type} should be deleted. Doing so may be destructive.\nYou can enable deletes by setting 'AUTH0_ALLOW_DELETE' to true in the config
         \n${changes.del.map(i => this.objString(i)).join('\n')}

--- a/tests/auth0/handlers/clientGrants.tests.js
+++ b/tests/auth0/handlers/clientGrants.tests.js
@@ -283,5 +283,33 @@ describe('#clientGrants handler', () => {
       await stageFn.apply(handler, [ { clientGrants: [] } ]);
       expect(removed).to.equal(true);
     });
+
+    it('should not delete client grants if run by extensions', async () => {
+      config.data = {
+        EXTENSION_SECRET: 'some-secret'
+      };
+
+      const auth0 = {
+        clientGrants: {
+          create: () => Promise.resolve([]),
+          update: () => Promise.resolve([]),
+          delete: (params) => {
+            expect(params).to.be.an('undefined');
+
+            return Promise.resolve([]);
+          },
+          getAll: () => [ { id: 'cg1', client_id: 'client1', audience: 'audience1' } ]
+        },
+        clients: {
+          getAll: () => []
+        },
+        pool
+      };
+
+      const handler = new clientGrants.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [ { clientGrants: [] } ]);
+    });
   });
 });

--- a/tests/auth0/handlers/clients.tests.js
+++ b/tests/auth0/handlers/clients.tests.js
@@ -237,5 +237,33 @@ describe('#clients handler', () => {
 
       await stageFn.apply(handler, [ assets ]);
     });
+
+    it('should not remove clients if run by extension', async () => {
+      config.data = {
+        EXTENSION_SECRET: 'some-secret'
+      };
+
+      const auth0 = {
+        clients: {
+          create: () => Promise.resolve([]),
+          update: () => Promise.resolve([]),
+          delete: (params) => {
+            expect(params).to.be.an('undefined');
+            return Promise.resolve([]);
+          },
+          getAll: () => [
+            { client_id: 'client1', name: 'existingClient' },
+            { client_id: 'client2', name: 'existingClient2' }
+          ]
+        },
+        pool
+      };
+
+
+      const handler = new clients.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [ { clients: [] } ]);
+    });
   });
 });

--- a/tests/auth0/handlers/connections.tests.js
+++ b/tests/auth0/handlers/connections.tests.js
@@ -235,5 +235,31 @@ describe('#connections handler', () => {
 
       await stageFn.apply(handler, [ { connections: data } ]);
     });
+
+    it('should not remove connections if run by extension', async () => {
+      config.data = {
+        EXTENSION_SECRET: 'some-secret'
+      };
+      const auth0 = {
+        connections: {
+          create: () => Promise.resolve(),
+          update: () => Promise.resolve([]),
+          delete: (params) => {
+            expect(params).to.be.an('undefined');
+            return Promise.resolve([]);
+          },
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'custom' } ]
+        },
+        clients: {
+          getAll: () => []
+        },
+        pool
+      };
+
+      const handler = new connections.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [ { connections: [] } ]);
+    });
   });
 });

--- a/tests/auth0/handlers/databases.tests.js
+++ b/tests/auth0/handlers/databases.tests.js
@@ -274,5 +274,31 @@ describe('#databases handler', () => {
 
       await stageFn.apply(handler, [ { databases: data } ]);
     });
+
+    it('should not remove if it is not allowed by config', async () => {
+      config.data = {
+        EXTENSION_SECRET: 'some-secret'
+      };
+      const auth0 = {
+        connections: {
+          create: () => Promise.resolve(),
+          update: () => Promise.resolve([]),
+          delete: (params) => {
+            expect(params).to.be.an('undefined');
+            return Promise.resolve([]);
+          },
+          getAll: () => [ { id: 'con1', name: 'existingConnection', strategy: 'auth0' } ]
+        },
+        clients: {
+          getAll: () => []
+        },
+        pool
+      };
+
+      const handler = new databases.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [ { databases: [] } ]);
+    });
   });
 });

--- a/tests/auth0/handlers/databases.tests.js
+++ b/tests/auth0/handlers/databases.tests.js
@@ -275,7 +275,7 @@ describe('#databases handler', () => {
       await stageFn.apply(handler, [ { databases: data } ]);
     });
 
-    it('should not remove if it is not allowed by config', async () => {
+    it('should not remove databases if run by extension', async () => {
       config.data = {
         EXTENSION_SECRET: 'some-secret'
       };

--- a/tests/auth0/handlers/resourceServers.tests.js
+++ b/tests/auth0/handlers/resourceServers.tests.js
@@ -151,7 +151,35 @@ describe('#resourceServers handler', () => {
       await stageFn.apply(handler, [ { resourceServers: [ {} ] } ]);
     });
 
-    it('should all remove resource servers', async () => {
+    it('should remove all resource servers', async () => {
+      let removed = false;
+      const auth0 = {
+        resourceServers: {
+          create: () => Promise.resolve([]),
+          update: () => Promise.resolve([]),
+          delete: (data) => {
+            expect(data).to.be.an('object');
+            expect(data.id).to.equal('rs1');
+            removed = true;
+            return Promise.resolve(data);
+          },
+          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
+        },
+        pool
+      };
+
+      const handler = new resourceServers.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [ { resourceServers: [] } ]);
+      expect(removed).to.equal(true);
+    });
+
+    it('should remove resource servers is run by extension', async () => {
+      config.data = {
+        EXTENSION_SECRET: 'some-secret'
+      };
+
       let removed = false;
       const auth0 = {
         resourceServers: {

--- a/tests/auth0/handlers/rules.tests.js
+++ b/tests/auth0/handlers/rules.tests.js
@@ -232,6 +232,34 @@ describe('#rules handler', () => {
       expect(removed).to.equal(true);
     });
 
+    it('should remove rules if run by extension', async () => {
+      config.data = {
+        EXTENSION_SECRET: 'some-secret'
+      };
+
+      let removed = false;
+      const auth0 = {
+        rules: {
+          create: () => Promise.resolve([]),
+          update: () => Promise.resolve([]),
+          delete: (data) => {
+            expect(data).to.be.an('object');
+            expect(data.id).to.equal('rule1');
+            removed = true;
+            return Promise.resolve(data);
+          },
+          getAll: () => [ { id: 'rule1', name: 'existingRule', order: '10' } ]
+        },
+        pool
+      };
+
+      const handler = new rules.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [ { rules: [] } ]);
+      expect(removed).to.equal(true);
+    });
+
     it('should not touch excluded rules', async () => {
       const auth0 = {
         rules: {


### PR DESCRIPTION
## ✏️ Changes
  Tools won't delete rules without `ALLOW_DELETE` flag, which cannot be used in deploy-extensions, as it'll lead to removing clients, connections and other stuff as well. 
Extensions should be able to remove only rules/resourceServers.

## 🔗 References
  GH Issue: https://github.com/auth0-extensions/auth0-deploy-extensions/issues/18
  
## 🎯 Testing
🚫 This change has been tested in a Webtask (need to be released and added to webtask first)
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  