### PR TITLE
Add support for roles and permissions for deploy-cli

### DIFF
--- a/src/auth0/handlers/index.js
+++ b/src/auth0/handlers/index.js
@@ -12,6 +12,7 @@ import * as clientGrants from './clientGrants';
 import * as guardianFactors from './guardianFactors';
 import * as guardianFactorProviders from './guardianFactorProviders';
 import * as guardianFactorTemplates from './guardianFactorTemplates';
+import * as roles from './roles';
 
 export {
   rules,
@@ -27,5 +28,6 @@ export {
   clientGrants,
   guardianFactors,
   guardianFactorProviders,
-  guardianFactorTemplates
+  guardianFactorTemplates,
+  roles
 };

--- a/src/auth0/handlers/resourceServers.js
+++ b/src/auth0/handlers/resourceServers.js
@@ -25,7 +25,9 @@ export const schema = {
             description: { type: 'string' }
           }
         }
-      }
+      },
+      enforce_policies: { type: 'boolean' },
+      token_dialect: { type: 'string' }
     },
     required: [ 'name', 'identifier' ]
   }

--- a/src/auth0/handlers/roles.js
+++ b/src/auth0/handlers/roles.js
@@ -35,10 +35,6 @@ export default class RoleHandler extends DefaultHandler {
     });
   }
 
-  objString(item) {
-    return super.objString({ name: item.name, id: item.id });
-  }
-
   async createRoles(creates) {
     await Promise.all(creates.map(async (roleData) => {
       const data = { ...roleData };

--- a/src/auth0/handlers/roles.js
+++ b/src/auth0/handlers/roles.js
@@ -1,0 +1,104 @@
+import DefaultHandler, { order } from './default';
+import { calcChanges } from '../../utils';
+
+export const schema = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      id: { type: 'string' },
+      description: { type: 'string' },
+      permissions: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            permission_name: { type: 'string' },
+            resource_server_identifier: { type: 'string' }
+          }
+        }
+      }
+    },
+    required: [ 'name' ]
+  }
+};
+
+export default class RoleHandler extends DefaultHandler {
+  constructor(config) {
+    super({
+      ...config,
+      type: 'roles',
+      id: 'id',
+      identifiers: [ 'name' ]
+    });
+  }
+
+  objString(item) {
+    return super.objString({ name: item.name, id: item.id, description: item.description });
+  }
+
+  async getType() {
+    if (this.existing) {
+      return this.existing;
+    }
+
+    const roles = await this.client.roles.getAll();
+    for (let index = 0; index < roles.length; index++) {
+      const permissions = await this.client.roles.permissions.get({ id: roles[index].id });
+      const strippedPerms = await Promise.all(permissions.map(async (permission) => {
+        delete permission.resource_server_name;
+        delete permission.description;
+        return permission;
+      }));
+      roles[index].permissions = strippedPerms;
+    }
+    this.existing = roles;
+    return this.existing;
+  }
+
+  @order('60')
+  async processChanges(assets) {
+    const { roles } = assets;
+
+    // Do nothing if not set
+    if (!roles) return;
+
+    // Gets roles from destination tenant
+    const existing = await this.getType();
+
+    const changes = calcChanges(roles, existing, [ 'id', 'name' ]);
+
+    await Promise.all(changes.create.map(async (createRole) => {
+      const data = { ...createRole };
+      delete data.permissions;
+      const created = await this.client.roles.create(data);
+      if (typeof createRole.permissions !== 'undefined' && createRole.permissions.length > 0) await this.client.roles.permissions.create({ id: created.id }, { permissions: createRole.permissions });
+      this.didCreate(created);
+      this.created += 1;
+    }));
+
+    await Promise.all(changes.update.map(async (updateRole) => {
+      const data = await roles.find(roleDataForUpdate => roleDataForUpdate.name === updateRole.name);
+      const params = { id: updateRole.id };
+      const newPermissions = data.permissions;
+      delete data.permissions;
+      await this.client.roles.update(params, data);
+
+      if (typeof updateRole.permissions !== 'undefined' && updateRole.permissions.length > 0) {
+        const deleteAllowed = this.config.AUTH0_ALLOW_DELETE;
+        if (!deleteAllowed) this.config.AUTH0_ALLOW_DELETE = true;
+        await this.client.roles.permissions.delete(params, { permissions: updateRole.permissions });
+        if (!deleteAllowed) this.config.AUTH0_ALLOW_DELETE = false;
+      }
+      if (typeof newPermissions !== 'undefined' && newPermissions.length > 0) await this.client.roles.permissions.create(params, { permissions: newPermissions });
+
+      this.didUpdate(params);
+      this.updated += 1;
+    }));
+
+    await super.processChanges(assets, {
+      del: changes.del
+    });
+  }
+}

--- a/src/auth0/handlers/roles.js
+++ b/src/auth0/handlers/roles.js
@@ -36,7 +36,7 @@ export default class RoleHandler extends DefaultHandler {
   }
 
   objString(item) {
-    return super.objString({ name: item.name, id: item.id, description: item.description });
+    return super.objString({ name: item.name, id: item.id });
   }
 
   async createRoles(creates) {

--- a/src/auth0/handlers/roles.js
+++ b/src/auth0/handlers/roles.js
@@ -39,6 +39,43 @@ export default class RoleHandler extends DefaultHandler {
     return super.objString({ name: item.name, id: item.id, description: item.description });
   }
 
+  async createRole(roleData) {
+    const data = { ...roleData };
+    delete data.permissions;
+    const created = await this.client.roles.create(data);
+    if (typeof roleData.permissions !== 'undefined' && roleData.permissions.length > 0) await this.client.roles.permissions.create({ id: created.id }, { permissions: roleData.permissions });
+    return created;
+  }
+
+  async deleteRoles(dels) {
+    if (this.config('AUTH0_ALLOW_DELETE') === 'true' || this.config('AUTH0_ALLOW_DELETE') === true) {
+      await Promise.all(dels.map(async (roleToDelete) => {
+        await this.client.roles.delete({ id: roleToDelete.id });
+        this.didDelete(roleToDelete);
+        this.deleted += 1;
+      }));
+    } else {
+      log.warn(`Detected the following roles should be deleted. Doing so may be destructive.\nYou can enable deletes by setting 'AUTH0_ALLOW_DELETE' to true in the config
+      \n${dels.map(i => this.objString(i)).join('\n')}`);
+    }
+  }
+
+  async updateRole(updateRole, roles) {
+    const data = await roles.find(roleDataForUpdate => roleDataForUpdate.name === updateRole.name);
+    const params = { id: updateRole.id };
+    const newPermissions = data.permissions;
+    delete data.permissions;
+    await this.client.roles.update(params, data);
+    if (typeof updateRole.permissions !== 'undefined' && updateRole.permissions.length > 0) {
+      const deleteAllowed = this.config.AUTH0_ALLOW_DELETE;
+      if (!deleteAllowed) this.config.AUTH0_ALLOW_DELETE = true;
+      await this.client.roles.permissions.delete(params, { permissions: updateRole.permissions });
+      if (!deleteAllowed) this.config.AUTH0_ALLOW_DELETE = false;
+    }
+    if (typeof newPermissions !== 'undefined' && newPermissions.length > 0) await this.client.roles.permissions.create(params, { permissions: newPermissions });
+    return params;
+  }
+
   async getType() {
     if (this.existing) {
       return this.existing;
@@ -61,54 +98,33 @@ export default class RoleHandler extends DefaultHandler {
   @order('60')
   async processChanges(assets) {
     const { roles } = assets;
-
     // Do nothing if not set
     if (!roles) return;
-
     // Gets roles from destination tenant
     const existing = await this.getType();
     const changes = calcChanges(roles, existing, [ 'id', 'name' ]);
-
     log.debug(`Start processChanges for roles [delete:${changes.del.length}] [update:${changes.update.length}], [create:${changes.create.length}]`);
-
-    await Promise.all(changes.create.map(async (createRole) => {
-      const data = { ...createRole };
-      delete data.permissions;
-      const created = await this.client.roles.create(data);
-      if (typeof createRole.permissions !== 'undefined' && createRole.permissions.length > 0) await this.client.roles.permissions.create({ id: created.id }, { permissions: createRole.permissions });
-      this.didCreate(created);
-      this.created += 1;
-    }));
-
-    await Promise.all(changes.update.map(async (updateRole) => {
-      const data = await roles.find(roleDataForUpdate => roleDataForUpdate.name === updateRole.name);
-      const params = { id: updateRole.id };
-      const newPermissions = data.permissions;
-      delete data.permissions;
-      await this.client.roles.update(params, data);
-
-      if (typeof updateRole.permissions !== 'undefined' && updateRole.permissions.length > 0) {
-        const deleteAllowed = this.config.AUTH0_ALLOW_DELETE;
-        if (!deleteAllowed) this.config.AUTH0_ALLOW_DELETE = true;
-        await this.client.roles.permissions.delete(params, { permissions: updateRole.permissions });
-        if (!deleteAllowed) this.config.AUTH0_ALLOW_DELETE = false;
+    const myChanges = [ { del: changes.del }, { create: changes.create }, { update: changes.update } ];
+    await Promise.all(myChanges.map(async (change) => {
+      switch (true) {
+        case change.del && change.del.length > 0:
+          this.deleteRoles(change.del);
+          break;
+        case change.create && change.create.length > 0:
+          await Promise.all(change.create.map(async (createRole) => {
+            this.didCreate(await this.createRole(createRole));
+            this.created += 1;
+          }));
+          break;
+        case change.update && change.update.length > 0:
+          await Promise.all(change.update.map(async (updateRole) => {
+            this.didUpdate(await this.updateRole(updateRole, roles));
+            this.updated += 1;
+          }));
+          break;
+        default:
+          break;
       }
-      if (typeof newPermissions !== 'undefined' && newPermissions.length > 0) await this.client.roles.permissions.create(params, { permissions: newPermissions });
-
-      this.didUpdate(params);
-      this.updated += 1;
     }));
-
-    if (changes.del.length > 0) {
-      const shouldDelete = this.config('AUTH0_ALLOW_DELETE') === 'true' || this.config('AUTH0_ALLOW_DELETE') === true;
-      if (!shouldDelete) {
-        log.warn(`Detected the following roles should be deleted. Doing so may be destructive.\nYou can enable deletes by setting 'AUTH0_ALLOW_DELETE' to true in the config
-        \n${changes.del.map(i => this.objString(i)).join('\n')}`);
-      } else {
-        await Promise.all(changes.del.map(async (roleToDelete) => {
-          await this.client.roles.delete({ id: roleToDelete.id });
-        }));
-      }
-    }
   }
 }

--- a/src/auth0/handlers/roles.js
+++ b/src/auth0/handlers/roles.js
@@ -67,8 +67,6 @@ export default class RoleHandler extends DefaultHandler {
 
     // Gets roles from destination tenant
     const existing = await this.getType();
-    
-    //Calculate changes
     const changes = calcChanges(roles, existing, [ 'id', 'name' ]);
 
     log.debug(`Start processChanges for roles [delete:${changes.del.length}] [update:${changes.update.length}], [create:${changes.create.length}]`);

--- a/src/constants.js
+++ b/src/constants.js
@@ -132,5 +132,6 @@ constants.CONNECTIONS_CLIENT_NAME = 'connections';
 constants.CONNECTIONS_ID_NAME = 'id';
 
 constants.CONCURRENT_CALLS = 5;
+constants.ROLES_DIRECTORY = 'roles';
 
 export default constants;

--- a/tests/auth0/handlers/roles.tests.js
+++ b/tests/auth0/handlers/roles.tests.js
@@ -71,26 +71,33 @@ describe('#roles handler', () => {
             get: () => [
               { permission_name: 'Create:cal_entry', resource_server_identifier: 'organise' }
             ],
-            create: (data) => {
-              expect(data).to.be.an('Array');
-              expect(data.length).to.equal(1);
-              return Promise.resolve(data);
-            },
-            update: (params, data) => {
+            create: (params, data) => {
               expect(params).to.be.an('object');
               expect(params.id).to.equal('myRoleId');
-              expect(data).to.be.an('Array');
-              expect(data[0].permission_name).to.equal('Create:cal_entry');
-              expect(data[0].descrresource_server_identifieription).to.equal('organise');
-              return Promise.resolve(data);
-            }
+              expect(data).to.be.an('object');
+              expect(data.permissions).to.not.equal(null);
+              expect(data.permissions).to.be.an('Array');
+              return Promise.resolve(data.permissions);
+            },
+            update: Promise.resolve([])
           }
         },
         pool
       };
       const handler = new roles.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
-      await stageFn.apply(handler, [ { roles: [ { name: 'myRole', description: 'myDescription' } ] } ]);
+      await stageFn.apply(handler, [
+        {
+          roles: [
+            {
+              name: 'myRole',
+              id: 'myRoleId',
+              description: 'myDescription',
+              permissions: []
+            }
+          ]
+        }
+      ]);
     });
 
     it('should get roles', async () => {
@@ -136,29 +143,39 @@ describe('#roles handler', () => {
             expect(params).to.be.an('object');
             expect(params.id).to.equal('myRoleId');
             expect(data).to.be.an('object');
-            expect(data.name).to.equal('myNewRoleName');
-            expect(data.description).to.equal('myNewDescription');
+            expect(data.name).to.equal('myRole');
+            expect(data.description).to.equal('myDescription');
 
             return Promise.resolve(data);
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ { id: 'myRoleId', name: 'myRole', description: 'myDescription' } ],
+          getAll: () => [
+            {
+              name: 'myRole',
+              id: 'myRoleId',
+              description: 'myDescription'
+            }
+          ],
           permissions: {
             get: () => [
               { permission_name: 'Create:cal_entry', resource_server_identifier: 'organise' }
             ],
-            create: (data) => {
-              expect(data).to.be.an('Array');
-              expect(data.length).to.equal(1);
-              return Promise.resolve(data);
-            },
-            update: (params, data) => {
+            getAll: () => [
+              { permission_name: 'Create:cal_entry', resource_server_identifier: 'organise' }
+            ],
+            create: (params, data) => {
               expect(params).to.be.an('object');
               expect(params.id).to.equal('myRoleId');
-              expect(data).to.be.an('Array');
-              expect(data[0].permission_name).to.equal('Create:cal_entry');
-              expect(data[0].descrresource_server_identifieription).to.equal('organise');
+              expect(data).to.be.an('object');
+              expect(data.permissions).to.not.equal(null);
+              expect(data.permissions).to.be.an('Array');
               return Promise.resolve(data);
+            },
+            delete: (params, data) => {
+              expect(params).to.be.an('object');
+              expect(params.id).to.equal('myRoleId');
+              expect(data.permissions).to.be.an('Array');
+              return Promise.resolve(data.permissions);
             }
           }
 
@@ -169,7 +186,22 @@ describe('#roles handler', () => {
       const handler = new roles.default({ client: auth0, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
-      await stageFn.apply(handler, [ { roles: [ { id: 'myRoleId', name: 'myNewRoleName', description: 'myNewDescription' } ] } ]);
+      await stageFn.apply(handler, [
+        {
+          roles: [
+            {
+              name: 'myRole',
+              id: 'myRoleId',
+              description: 'myDescription',
+              permissions: [
+                {
+                  permission_name: 'Create:cal_entry', resource_server_identifier: 'organise'
+                }
+              ]
+            }
+          ]
+        }
+      ]);
     });
 
     it('should delete role', async () => {
@@ -182,24 +214,20 @@ describe('#roles handler', () => {
             expect(data.id).to.equal('myRoleId');
             return Promise.resolve(data);
           },
-          getAll: () => [ { id: 'myRoleId', name: 'myRole', description: 'myDescription' } ],
-          permissions: {
-            get: () => [
-              { permission_name: 'Create:cal_entry', resource_server_identifier: 'organise' }
-            ],
-            create: (data) => {
-              expect(data).to.be.an('Array');
-              expect(data.length).to.equal(1);
-              return Promise.resolve(data);
-            },
-            update: (params, data) => {
-              expect(params).to.be.an('object');
-              expect(params.id).to.equal('myRoleId');
-              expect(data).to.be.an('Array');
-              expect(data[0].permission_name).to.equal('Create:cal_entry');
-              expect(data[0].descrresource_server_identifieription).to.equal('organise');
-              return Promise.resolve(data);
+          getAll: () => [
+            {
+              name: 'myRole',
+              id: 'myRoleId',
+              description: 'myDescription',
+              permissions: [
+                {
+                  permission_name: 'Create:cal_entry', resource_server_identifier: 'organise'
+                }
+              ]
             }
+          ],
+          permissions: {
+            get: () => []
           }
         },
         pool

--- a/tests/auth0/handlers/roles.tests.js
+++ b/tests/auth0/handlers/roles.tests.js
@@ -1,0 +1,212 @@
+const { expect } = require('chai');
+const roles = require('../../../src/auth0/handlers/roles');
+
+const pool = {
+  addEachTask: (data) => {
+    if (data.data && data.data.length) {
+      data.generator(data.data[0]);
+    }
+    return { promise: () => null };
+  }
+};
+
+describe('#roles handler', () => {
+  const config = function(key) {
+    return config.data && config.data[key];
+  };
+
+  config.data = {
+    AUTH0_CLIENT_ID: 'client_id',
+    AUTH0_ALLOW_DELETE: true
+  };
+
+  describe('#roles validate', () => {
+    it('should not allow same names', async () => {
+      const handler = new roles.default({ client: {}, config });
+      const stageFn = Object.getPrototypeOf(handler).validate;
+      const data = [
+        {
+          name: 'myRole'
+        },
+        {
+          name: 'myRole'
+        }
+      ];
+
+      try {
+        await stageFn.apply(handler, [ { roles: data } ]);
+      } catch (err) {
+        expect(err).to.be.an('object');
+        expect(err.message).to.include('Names must be unique');
+      }
+    });
+
+    it('should pass validation', async () => {
+      const handler = new roles.default({ client: {}, config });
+      const stageFn = Object.getPrototypeOf(handler).validate;
+      const data = [
+        {
+          name: 'myRole'
+        }
+      ];
+
+      await stageFn.apply(handler, [ { roles: data } ]);
+    });
+  });
+
+  describe('#roles process', () => {
+    it('should create role', async () => {
+      const auth0 = {
+        roles: {
+          create: (data) => {
+            expect(data).to.be.an('object');
+            expect(data.name).to.equal('myRole');
+            expect(data.description).to.equal('myDescription');
+            return Promise.resolve(data);
+          },
+          update: () => Promise.resolve([]),
+          delete: () => Promise.resolve([]),
+          getAll: () => [],
+          permissions: {
+            get: () => [
+              { permission_name: 'Create:cal_entry', resource_server_identifier: 'organise' }
+            ],
+            create: (data) => {
+              expect(data).to.be.an('Array');
+              expect(data.length).to.equal(1);
+              return Promise.resolve(data);
+            },
+            update: (params, data) => {
+              expect(params).to.be.an('object');
+              expect(params.id).to.equal('myRoleId');
+              expect(data).to.be.an('Array');
+              expect(data[0].permission_name).to.equal('Create:cal_entry');
+              expect(data[0].descrresource_server_identifieription).to.equal('organise');
+              return Promise.resolve(data);
+            }
+          }
+        },
+        pool
+      };
+      const handler = new roles.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [ { roles: [ { name: 'myRole', description: 'myDescription' } ] } ]);
+    });
+
+    it('should get roles', async () => {
+      const auth0 = {
+        roles: {
+          getAll: () => [
+            { name: 'myRole', id: 'myRoleId', description: 'myDescription' }
+          ],
+          permissions: {
+            get: () => [
+              { permission_name: 'Create:cal_entry', resource_server_identifier: 'organise' }
+            ]
+          }
+        },
+        pool
+      };
+
+      const handler = new roles.default({ client: auth0, config });
+      const data = await handler.getType();
+      expect(data).to.deep.equal([
+        {
+          name: 'myRole',
+          id: 'myRoleId',
+          description: 'myDescription',
+          permissions: [
+            {
+              permission_name: 'Create:cal_entry', resource_server_identifier: 'organise'
+            }
+          ]
+        }
+      ]);
+    });
+
+    it('should update role', async () => {
+      const auth0 = {
+        roles: {
+          create: (data) => {
+            expect(data).to.be.an('object');
+            expect(data.length).to.equal(0);
+            return Promise.resolve(data);
+          },
+          update: (params, data) => {
+            expect(params).to.be.an('object');
+            expect(params.id).to.equal('myRoleId');
+            expect(data).to.be.an('object');
+            expect(data.name).to.equal('myNewRoleName');
+            expect(data.description).to.equal('myNewDescription');
+
+            return Promise.resolve(data);
+          },
+          delete: () => Promise.resolve([]),
+          getAll: () => [ { id: 'myRoleId', name: 'myRole', description: 'myDescription' } ],
+          permissions: {
+            get: () => [
+              { permission_name: 'Create:cal_entry', resource_server_identifier: 'organise' }
+            ],
+            create: (data) => {
+              expect(data).to.be.an('Array');
+              expect(data.length).to.equal(1);
+              return Promise.resolve(data);
+            },
+            update: (params, data) => {
+              expect(params).to.be.an('object');
+              expect(params.id).to.equal('myRoleId');
+              expect(data).to.be.an('Array');
+              expect(data[0].permission_name).to.equal('Create:cal_entry');
+              expect(data[0].descrresource_server_identifieription).to.equal('organise');
+              return Promise.resolve(data);
+            }
+          }
+
+        },
+        pool
+      };
+
+      const handler = new roles.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [ { roles: [ { id: 'myRoleId', name: 'myNewRoleName', description: 'myNewDescription' } ] } ]);
+    });
+
+    it('should delete role', async () => {
+      const auth0 = {
+        roles: {
+          create: () => Promise.resolve([]),
+          update: () => Promise.resolve([]),
+          delete: (data) => {
+            expect(data).to.be.an('object');
+            expect(data.id).to.equal('myRoleId');
+            return Promise.resolve(data);
+          },
+          getAll: () => [ { id: 'myRoleId', name: 'myRole', description: 'myDescription' } ],
+          permissions: {
+            get: () => [
+              { permission_name: 'Create:cal_entry', resource_server_identifier: 'organise' }
+            ],
+            create: (data) => {
+              expect(data).to.be.an('Array');
+              expect(data.length).to.equal(1);
+              return Promise.resolve(data);
+            },
+            update: (params, data) => {
+              expect(params).to.be.an('object');
+              expect(params.id).to.equal('myRoleId');
+              expect(data).to.be.an('Array');
+              expect(data[0].permission_name).to.equal('Create:cal_entry');
+              expect(data[0].descrresource_server_identifieription).to.equal('organise');
+              return Promise.resolve(data);
+            }
+          }
+        },
+        pool
+      };
+      const handler = new roles.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      await stageFn.apply(handler, [ { roles: [ {} ] } ]);
+    });
+  });
+});


### PR DESCRIPTION
## ✏️ Changes
  
> Adding roles handler for managing roles and permissions via the deploy-cli
> Added src/auth0/handlers/roles.js and tests/auth0/handlers/roles.tests.js, changed src/auth0/handlers/index.js and src/constants.js. Also changed src/auth0/handlers/resourceServers.j to add support for 2 new properties enforce_policies and token_dialect
    
## 🎯 Testing
> - Added unit tests for roles handler
> - If this is on a hot path, add load or performance tests
> - Especially for dependency updates we also need to make sure that there is no impact on performance.
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
## 🚀 Deployment
  
> For roles functionality this change requires a new version of the node-auth0 package. `https://github.com/auth0/node-auth0`. Specifically `https://github.com/auth0/node-auth0/blob/master/src/management/RolesManager.js`
  
🚫This can only be deployed and released with node-auth0 that contains support for roles. As mentioned above!!.
A new version of node-auth0 v2.17.0 was released on 04/15/2019 - This version supports roles and is the one to be used

