### PR TITLE
 calcChanges for resourceServers by 'identifier'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/resourceServers.js
+++ b/src/auth0/handlers/resourceServers.js
@@ -67,7 +67,7 @@ export default class ResourceServersHandler extends DefaultHandler {
     resourceServers = resourceServers.filter(r => !excluded.includes(r.name));
     existing = existing.filter(r => !excluded.includes(r.name));
 
-    return calcChanges(resourceServers, existing, [ 'id', 'name' ]);
+    return calcChanges(resourceServers, existing, [ 'id', 'identifier' ]);
   }
 
   async validate(assets) {

--- a/tests/auth0/handlers/resourceServers.tests.js
+++ b/tests/auth0/handlers/resourceServers.tests.js
@@ -130,6 +130,33 @@ describe('#resourceServers handler', () => {
       await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI', identifier: 'some-api', scope: 'new:scope' } ] } ]);
     });
 
+    it('should create new resource server with same name but different identifier', async () => {
+      const auth0 = {
+        resourceServers: {
+          create: (data) => {
+            expect(data).to.be.an('object');
+            expect(data.name).to.equal('someAPI');
+            expect(data.scope).to.equal('new:scope');
+            expect(data.identifier).to.equal('another-api');
+            return Promise.resolve(data);
+          },
+          update: (params, data) => {
+            expect(params).to.be('undefined');
+            expect(data).to.be('undefined');
+            return Promise.resolve(data);
+          },
+          delete: () => Promise.resolve([]),
+          getAll: () => [ { id: 'rs1', identifier: 'some-api', name: 'someAPI' } ]
+        },
+        pool
+      };
+
+      const handler = new resourceServers.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [ { resourceServers: [ { name: 'someAPI', identifier: 'another-api', scope: 'new:scope' } ] } ]);
+    });
+
     it('should remove resource server', async () => {
       const auth0 = {
         resourceServers: {


### PR DESCRIPTION
## ✏️ Changes
  `identifier` of resource server cannot be changed. That means changing `identifier` in `tenant.yaml` has no effect (see https://github.com/auth0/auth0-deploy-cli/issues/129). Using `identifier` instead of `name` to identify resource server allows cli to create new api with desired `identifier` and, if ALLOW_DELETE is enabled, replace old api (with old `identifier`). Even if old api won't be deleted, `name` isn't unique, so we can have two apis with different identifiers but with same name.
  
## 🔗 References
  GH issue: https://github.com/auth0/auth0-deploy-cli/issues/129
  
## 🎯 Testing
✅ This change has been tested in a locally
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance