### PR TITLE
Continue processing if hooks or roles are not enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/roles.js
+++ b/src/auth0/handlers/roles.js
@@ -83,7 +83,7 @@ export default class RoleHandler extends DefaultHandler {
 
     // in case client version does not support roles
     if (!this.client.roles || typeof this.client.roles.getAll !== 'function') {
-      return {};
+      return [];
     }
 
     try {
@@ -100,8 +100,9 @@ export default class RoleHandler extends DefaultHandler {
       this.existing = roles;
       return this.existing;
     } catch (err) {
-      if (err.statusCode === 404) return {};
-      if (err.statusCode === 501) return {};
+      if (err.statusCode === 404 || err.statusCode === 501) {
+        return [];
+      }
       throw err;
     }
   }

--- a/tests/auth0/handlers/roles.tests.js
+++ b/tests/auth0/handlers/roles.tests.js
@@ -131,6 +131,61 @@ describe('#roles handler', () => {
       ]);
     });
 
+    it('should return an empty array for 501 status code', async () => {
+      const auth0 = {
+        roles: {
+          getAll: () => {
+            const error = new Error('Feature is not yet implemented');
+            error.statusCode = 501;
+            throw error;
+          }
+        },
+        pool
+      };
+
+      const handler = new roles.default({ client: auth0, config });
+      const data = await handler.getType();
+      expect(data).to.deep.equal([]);
+    });
+
+    it('should return an empty array for 404 status code', async () => {
+      const auth0 = {
+        roles: {
+          getAll: () => {
+            const error = new Error('Not found');
+            error.statusCode = 404;
+            throw error;
+          }
+        },
+        pool
+      };
+
+      const handler = new roles.default({ client: auth0, config });
+      const data = await handler.getType();
+      expect(data).to.deep.equal([]);
+    });
+
+
+    it('should throw an error for all other failed requests', async () => {
+      const auth0 = {
+        roles: {
+          getAll: () => {
+            const error = new Error('Bad request');
+            error.statusCode = 500;
+            throw error;
+          }
+        },
+        pool
+      };
+
+      const handler = new roles.default({ client: auth0, config });
+      try {
+        await handler.getType();
+      } catch (error) {
+        expect(error).to.be.an.instanceOf(Error);
+      }
+    });
+
     it('should update role', async () => {
       const auth0 = {
         roles: {


### PR DESCRIPTION
## ✏️ Changes
  
Fixes to address multiple issues with auth0-deploy-cli when roles or hooks are not available due to tenant settings or unsupported APIs in environments.
* For roles, return empty arrays instead of objs to resolve `object not iterable` errors on import.
* For hooks, handle error status codes, specifically `403` in PSaaS envs, and return an empty array.
  
## 🔗 References
  
https://github.com/auth0/auth0-deploy-cli/issues/202
https://github.com/auth0-extensions/auth0-source-control-extension-tools/issues/78

  
## 🎯 Testing
  
Tested in environments with no roles and a disabled hooks API to replicate the errors and resolve. 
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅ This can be deployed any time
  
## 🎡 Rollout
  
Once released, this change will be manually tested in the auth0-deploy-cli to verify it works as expected. 
 
