### PR TITLE
Updated to not default to [] when enabled_clients key is missing

### DIFF
--- a/src/auth0/handlers/connections.js
+++ b/src/auth0/handlers/connections.js
@@ -54,16 +54,22 @@ export default class ConnectionsHandler extends DefaultHandler {
       return (found && found.client_id) || clientName;
     });
 
-    const formatted = assets.connections.map(connection => ({
-      ...connection,
-      enabled_clients: [
-        ...(connection.enabled_clients || []).map((name) => {
-          const found = clients.find(c => c.name === name);
-          if (found) return found.client_id;
-          return name;
-        }).filter(item => ![ ...excludedClientsByNames, ...excludedClients ].includes(item))
-      ]
-    }));
+    const formatted = assets.connections.map((connection) => {
+      // If the enabled_clients node isn't there, don't try and process it
+      if (!connection.enabled_clients) {
+        return connection;
+      }
+      return {
+        ...connection,
+        enabled_clients: [
+          ...(connection.enabled_clients || []).map((name) => {
+            const found = clients.find(c => c.name === name);
+            if (found) return found.client_id;
+            return name;
+          }).filter(item => ![ ...excludedClientsByNames, ...excludedClients ].includes(item))
+        ]
+      };
+    });
 
     return super.calcChanges({ ...assets, connections: formatted });
   }

--- a/tests/auth0/handlers/connections.tests.js
+++ b/tests/auth0/handlers/connections.tests.js
@@ -144,6 +144,46 @@ describe('#connections handler', () => {
       await stageFn.apply(handler, [ { connections: data } ]);
     });
 
+    it("should not place empty array when enabled_clients isn't set", async () => {
+      const auth0 = {
+        connections: {
+          create: (data) => {
+            expect(data).to.be.an('undefined');
+            return Promise.resolve(data);
+          },
+          update: (params, data) => {
+            expect(params).to.be.an('object');
+            expect(params.id).to.equal('con1');
+            expect(data).to.deep.equal({
+              options: { passwordPolicy: 'testPolicy' }
+            });
+
+            return Promise.resolve({ ...params, ...data });
+          },
+          delete: () => Promise.resolve([]),
+          getAll: () => [ { name: 'someConnection', id: 'con1', strategy: 'custom' } ]
+        },
+        clients: {
+          getAll: () => []
+        },
+        pool
+      };
+
+      const handler = new connections.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+      const data = [
+        {
+          name: 'someConnection',
+          strategy: 'custom',
+          options: {
+            passwordPolicy: 'testPolicy'
+          }
+        }
+      ];
+
+      await stageFn.apply(handler, [ { connections: data } ]);
+    });
+
     it('should omit excluded clients', async () => {
       const auth0 = {
         connections: {


### PR DESCRIPTION
## ✏️ Changes
  
This changed the behavior for connections. When missing the enabled_clients key it will not not persist any change.
  
## 📷 Screenshots
 
I don't have screenshots as it's a auth0 cli change.
  
## 🔗 References
  
Here is the issue I reported https://github.com/auth0/auth0-deploy-cli/issues/207. I had originally assumed that this was due to code in the CLI, however upon testing that I discovered it was here. The bug still exists there as that's the application the bug is surfaced.
  
## 🎯 Testing
  
I added a unit test to validate the behavior.
  
## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅ This can be deployed any time
  
## 🎡 Rollout
  
In order to verify that the deployment was successful we will test this will a modified version of the auth0 CLI to make sure the deployment changes are as expected.
  
## 🔥 Rollback
  
We will rollback if the changes are not what we expect.
  
### 📄 Procedure
  
The commit can be reverted if need be.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
