### PR TITLE
Esd 3907 fix rule ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.0.3",
+  "version": "4.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/rules.js
+++ b/src/auth0/handlers/rules.js
@@ -87,7 +87,10 @@ export default class RulesHandler extends DefaultHandler {
 
     // Figure out the rules that need to be re-ordered
     const futureRules = [ ...create, ...update ];
-    let nextOrderNo = Math.max(Math.max(...futureRules.map(r => r.order)), Math.max(...existing.map(r => r.order)));
+
+    const futureMaxOrder = Math.max(...futureRules.map(r => r.order));
+    const existingMaxOrder = Math.max(...existing.map(r => r.order));
+    let nextOrderNo = Math.max(futureMaxOrder, existingMaxOrder);
 
     const reOrder = futureRules.reduce((accum, r) => {
       const conflict = existing.find(f => r.order === f.order && r.name !== f.name);

--- a/src/auth0/handlers/rules.js
+++ b/src/auth0/handlers/rules.js
@@ -87,7 +87,7 @@ export default class RulesHandler extends DefaultHandler {
 
     // Figure out the rules that need to be re-ordered
     const futureRules = [ ...create, ...update ];
-    let nextOrderNo = Math.max(...existing.map(r => r.order)) + 1;
+    let nextOrderNo = Math.max(Math.max(...futureRules.map(r => r.order)), Math.max(...existing.map(r => r.order)));
 
     const reOrder = futureRules.reduce((accum, r) => {
       const conflict = existing.find(f => r.order === f.order && r.name !== f.name);

--- a/tests/auth0/handlers/rules.tests.js
+++ b/tests/auth0/handlers/rules.tests.js
@@ -74,7 +74,7 @@ describe('#rules handler', () => {
       }
     });
 
-    it('should not collision order when rules are reordered', async () => {
+    it('should not have a rules\' order collision when rules are reordered with future rule set no consecutive', async () => {
       const auth0 = {
         rules: {
           getAll: () => [
@@ -100,6 +100,44 @@ describe('#rules handler', () => {
         {
           name: 'Rule4',
           order: 4
+        }
+      ];
+
+      const output = await stageFn.apply(handler, [ { rules: data } ], true);
+      const newRulesOrder = [ ...output.create, ...output.update ].map(rule => rule.order);
+      const reorderedRulesOrder = output.reOrder.map(rule => rule.order);
+
+      //  check if there is no collisions between rules order
+      const checker = (arr, target) => target.every(v => arr.includes(v));
+      expect(checker(newRulesOrder, reorderedRulesOrder)).to.be.equal(false);
+    });
+
+    it('should not have a rules\' order collision when rules are reordered with future rule set consecutive', async () => {
+      const auth0 = {
+        rules: {
+          getAll: () => [
+            {
+              name: 'Rule1',
+              order: 1
+            },
+            {
+              name: 'Rule2',
+              order: 2
+            }
+          ]
+        }
+      };
+
+      const handler = new rules.default({ client: auth0, config });
+      const stageFn = Object.getPrototypeOf(handler).calcChanges;
+      const data = [
+        {
+          name: 'Rule3',
+          order: 2
+        },
+        {
+          name: 'Rule4',
+          order: 3
         }
       ];
 


### PR DESCRIPTION
## ✏️ Changes
  
When two rules with a different name but the same order collision, the reorder algorithm take the max order of all existing rules as the next available order for a rule, but this order could be the order of some of the new rules so when trying to create this set of rules they are rejected by `APIError: {"statusCode":409,"error":"Conflict","message":"A rule with the same order already exists","errorCode":"rule_conflict"}`

This fix takes into account both existing rules and new rules order to get the next available order in case of collision, assuring that that new order no exists as the order of existing rules or new rules. 
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/ESD-3907
  
## 🎯 Testing
   
✅ This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
 
✅ This can be deployed any time
  
## 🎡 Rollout
  
> Explain how the change will be verified once released. Manual testing? Functional testing?
  
In order to verify that the deployment was successful we will …
  
## 🔥 Rollback
  
> Explain when and why we will rollback the change.
  
We will rollback if …
  
### 📄 Procedure
  
> Explain how the rollback for this change will look like, how we can recover fast.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
