### PR TITLE
add `send-phone-message` triggerId for MFA SMS hook.

### DIFF
--- a/src/auth0/handlers/hooks.js
+++ b/src/auth0/handlers/hooks.js
@@ -1,7 +1,7 @@
 import DefaultHandler from './default';
 import constants from '../../constants';
 
-const ALLOWED_TRIGGER_IDS = [ 'credentials-exchange', 'pre-user-registration', 'post-user-registration', 'post-change-password' ];
+const ALLOWED_TRIGGER_IDS = [ 'credentials-exchange', 'pre-user-registration', 'post-user-registration', 'post-change-password', 'send-phone-message' ];
 
 export const excludeSchema = {
   type: 'array',

--- a/tests/auth0/handlers/hooks.tests.js
+++ b/tests/auth0/handlers/hooks.tests.js
@@ -130,6 +130,12 @@ describe('#hooks handler', () => {
           code: 'code',
           active: false,
           triggerId: 'post-change-password'
+        },
+        {
+          name: 'Hook-7',
+          code: 'code',
+          active: false,
+          triggerId: 'send-phone-message'
         }
       ];
 


### PR DESCRIPTION
## ✏️ Changes
 
- hooks: support for send-phone-message triggerId

## 📷 Screenshots
 
N/A
  
## 🔗 References
  
Adding the send-phone-message trigger to support the new [MFA SMS Hook](https://auth0.com/docs/hooks/extensibility-points/send-phone-message)
  
## 🎯 Testing
  
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?

  
## 🎡 Rollout
  
A hook with triggerId = send-phone-message can be successfully created with an extension tool.  
  
## 🔥 Rollback
    
  
### 📄 Procedure