### PR TITLE
[DXEX-629] validator: update schema for error_page in pages

### DIFF
--- a/src/auth0/handlers/pages.js
+++ b/src/auth0/handlers/pages.js
@@ -11,6 +11,7 @@ export const pageNameMap = {
   error_page: 'error_page'
 };
 
+// With this schema, we can only validate property types but not valid properties on per type basis
 export const schema = {
   type: 'array',
   items: {
@@ -18,6 +19,8 @@ export const schema = {
     properties: {
       name: { type: 'string', enum: supportedPages },
       html: { type: 'string', default: '' },
+      url: { type: 'string', default: '' },
+      show_log_link: { type: 'boolean' },
       enabled: { type: 'boolean' }
     },
     required: [ 'name' ]


### PR DESCRIPTION
## ✏️ Changes
  
Previously two properties of `error_page` type page were not defined in the schema for `pages`:
- `url`
- `show_log_link`

They are now added to the schema and test cases were added to ensure the validator can enforce the types.
  
## 📷 Screenshots
 
N/A
  
## 🔗 References
  
- https://auth0team.atlassian.net/browse/DXEX-629
- Documentation on universal login error page: https://auth0.com/docs/universal-login/error-pages
- Management APIv2 explorer for tenant settings of `error_page`: https://auth0.com/docs/api/management/v2#!/Tenants/patch_settings
  
## 🎯 Testing
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
    
✅ This can be deployed any time
  
## 🎡 Rollout
    
In order to verify that the deployment was successful we will …
1. Specify `url` and `show_log_link` in  an `error_page` object in `pages` configuration 
2. Deploy the configuration via either `deploy-cli` with updated version of this library `auth0-source-control-extension-tools`
3. Validate that if wrong type of data is provided, the `deploy-cli` should report error and reject the configuration
4. Validate that if the correct data is provided, the error_page of the tenant settings are deployed accordingly using management API: https://auth0.com/docs/api/management/v2#!/Tenants/patch_settings
  
## 🔥 Rollback
  
If unexpected error occurs, the dependency of the deploy-cli or deploy extension on this update library should be reverted.
  
### 📄 Procedure
  
Downgrade the dependency of this library to a previous version
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
