### PR TITLE
[MFA-311] Support guardian policies, phone selected-provider and message-types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/guardianPhoneFactorMessageTypes.js
+++ b/src/auth0/handlers/guardianPhoneFactorMessageTypes.js
@@ -1,0 +1,52 @@
+import DefaultHandler from './default';
+import constants from '../../constants';
+
+export const schema = {
+  type: 'object',
+  properties: {
+    message_types: {
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: constants.GUARDIAN_PHONE_MESSAGE_TYPES
+      }
+    }
+  },
+  required: [ 'message_types' ],
+  additionalProperties: false
+};
+
+
+export default class GuardianPhoneMessageTypesHandler extends DefaultHandler {
+  constructor(options) {
+    super({
+      ...options,
+      type: 'guardianPhoneFactorMessageTypes'
+    });
+  }
+
+  async getType() {
+    // in case client version does not support the operation
+    if (!this.client.guardian || typeof this.client.guardian.getPhoneFactorMessageTypes !== 'function') {
+      return null;
+    }
+
+    if (this.existing) return this.existing;
+    this.existing = await this.client.guardian.getPhoneFactorMessageTypes();
+    return this.existing;
+  }
+
+  async processChanges(assets) {
+    // No API to delete or create guardianPhoneFactorMessageTypes, we can only update.
+    const { guardianPhoneFactorMessageTypes } = assets;
+
+    // Do nothing if not set
+    if (!guardianPhoneFactorMessageTypes) return;
+
+    const params = {};
+    const data = guardianPhoneFactorMessageTypes;
+    await this.client.guardian.updatePhoneFactorMessageTypes(params, data);
+    this.updated += 1;
+    this.didUpdate(guardianPhoneFactorMessageTypes);
+  }
+}

--- a/src/auth0/handlers/guardianPhoneFactorSelectedProvider.js
+++ b/src/auth0/handlers/guardianPhoneFactorSelectedProvider.js
@@ -1,0 +1,49 @@
+import DefaultHandler from './default';
+import constants from '../../constants';
+
+export const schema = {
+  type: 'object',
+  properties: {
+    provider: {
+      type: 'string',
+      enum: constants.GUARDIAN_PHONE_PROVIDERS
+    }
+  },
+  required: [ 'provider' ],
+  additionalProperties: false
+};
+
+
+export default class GuardianPhoneSelectedProviderHandler extends DefaultHandler {
+  constructor(options) {
+    super({
+      ...options,
+      type: 'guardianPhoneFactorSelectedProvider'
+    });
+  }
+
+  async getType() {
+    // in case client version does not support the operation
+    if (!this.client.guardian || typeof this.client.guardian.getPhoneFactorSelectedProvider !== 'function') {
+      return null;
+    }
+
+    if (this.existing) return this.existing;
+    this.existing = await this.client.guardian.getPhoneFactorSelectedProvider();
+    return this.existing;
+  }
+
+  async processChanges(assets) {
+    // No API to delete or create guardianPhoneFactorSelectedProvider, we can only update.
+    const { guardianPhoneFactorSelectedProvider } = assets;
+
+    // Do nothing if not set
+    if (!guardianPhoneFactorSelectedProvider) return;
+
+    const params = {};
+    const data = guardianPhoneFactorSelectedProvider;
+    await this.client.guardian.updatePhoneFactorSelectedProvider(params, data);
+    this.updated += 1;
+    this.didUpdate(guardianPhoneFactorSelectedProvider);
+  }
+}

--- a/src/auth0/handlers/guardianPolicies.js
+++ b/src/auth0/handlers/guardianPolicies.js
@@ -1,0 +1,47 @@
+import DefaultHandler from './default';
+import constants from '../../constants';
+
+export const schema = {
+  type: 'array',
+  items: {
+    type: 'string',
+    enum: constants.GUARDIAN_POLICIES
+  },
+  minLength: 0,
+  maxLength: 1
+};
+
+
+export default class GuardianPoliciesHandler extends DefaultHandler {
+  constructor(options) {
+    super({
+      ...options,
+      type: 'guardianPolicies'
+    });
+  }
+
+  async getType() {
+    // in case client version does not support the operation
+    if (!this.client.guardian || typeof this.client.guardian.getPolicies !== 'function') {
+      return null;
+    }
+
+    if (this.existing) return this.existing;
+    this.existing = await this.client.guardian.getPolicies();
+    return this.existing;
+  }
+
+  async processChanges(assets) {
+    // No API to delete or create guardianPolicies, we can only update.
+    const { guardianPolicies } = assets;
+
+    // Do nothing if not set
+    if (!guardianPolicies) return;
+
+    const params = {};
+    const data = guardianPolicies;
+    await this.client.guardian.updatePolicies(params, data);
+    this.updated += 1;
+    this.didUpdate(guardianPolicies);
+  }
+}

--- a/src/auth0/handlers/index.js
+++ b/src/auth0/handlers/index.js
@@ -15,6 +15,7 @@ import * as guardianFactorProviders from './guardianFactorProviders';
 import * as guardianFactorTemplates from './guardianFactorTemplates';
 import * as guardianPolicies from './guardianPolicies';
 import * as guardianPhoneFactorSelectedProvider from './guardianPhoneFactorSelectedProvider';
+import * as guardianPhoneFactorMessageTypes from './guardianPhoneFactorMessageTypes';
 import * as roles from './roles';
 import * as branding from './branding';
 import * as prompts from './prompts';
@@ -37,6 +38,7 @@ export {
   guardianFactorTemplates,
   guardianPolicies,
   guardianPhoneFactorSelectedProvider,
+  guardianPhoneFactorMessageTypes,
   roles,
   branding,
   prompts

--- a/src/auth0/handlers/index.js
+++ b/src/auth0/handlers/index.js
@@ -14,6 +14,7 @@ import * as guardianFactors from './guardianFactors';
 import * as guardianFactorProviders from './guardianFactorProviders';
 import * as guardianFactorTemplates from './guardianFactorTemplates';
 import * as guardianPolicies from './guardianPolicies';
+import * as guardianPhoneFactorSelectedProvider from './guardianPhoneFactorSelectedProvider';
 import * as roles from './roles';
 import * as branding from './branding';
 import * as prompts from './prompts';
@@ -35,6 +36,7 @@ export {
   guardianFactorProviders,
   guardianFactorTemplates,
   guardianPolicies,
+  guardianPhoneFactorSelectedProvider,
   roles,
   branding,
   prompts

--- a/src/auth0/handlers/index.js
+++ b/src/auth0/handlers/index.js
@@ -13,6 +13,7 @@ import * as clientGrants from './clientGrants';
 import * as guardianFactors from './guardianFactors';
 import * as guardianFactorProviders from './guardianFactorProviders';
 import * as guardianFactorTemplates from './guardianFactorTemplates';
+import * as guardianPolicies from './guardianPolicies';
 import * as roles from './roles';
 import * as branding from './branding';
 import * as prompts from './prompts';
@@ -33,6 +34,7 @@ export {
   guardianFactors,
   guardianFactorProviders,
   guardianFactorTemplates,
+  guardianPolicies,
   roles,
   branding,
   prompts

--- a/src/constants.js
+++ b/src/constants.js
@@ -110,6 +110,10 @@ constants.GUARDIAN_FACTORS = [
   'email',
   'duo'
 ];
+constants.GUARDIAN_POLICIES = [
+  'all-applications',
+  'confidence-score'
+];
 
 constants.GUARDIAN_FACTOR_TEMPLATES = [
   'sms'

--- a/src/constants.js
+++ b/src/constants.js
@@ -114,6 +114,11 @@ constants.GUARDIAN_POLICIES = [
   'all-applications',
   'confidence-score'
 ];
+constants.GUARDIAN_PHONE_PROVIDERS = [
+  'auth0',
+  'twilio',
+  'phone-message-hook'
+];
 
 constants.GUARDIAN_FACTOR_TEMPLATES = [
   'sms'

--- a/src/constants.js
+++ b/src/constants.js
@@ -119,6 +119,10 @@ constants.GUARDIAN_PHONE_PROVIDERS = [
   'twilio',
   'phone-message-hook'
 ];
+constants.GUARDIAN_PHONE_MESSAGE_TYPES = [
+  'sms',
+  'voice'
+];
 
 constants.GUARDIAN_FACTOR_TEMPLATES = [
   'sms'

--- a/tests/auth0/handlers/guardianPhoneFactorMessageTypes.tests.js
+++ b/tests/auth0/handlers/guardianPhoneFactorMessageTypes.tests.js
@@ -1,0 +1,68 @@
+const { expect } = require('chai');
+const guardianPhoneFactorMessageTypes = require('../../../src/auth0/handlers/guardianPhoneFactorMessageTypes');
+
+describe('#guardianPhoneFactorMessageTypes handler', () => {
+  describe('#getType', () => {
+    it('should support older version of auth0 client', async () => {
+      const auth0 = {
+        guardian: {
+          // omitting getPhoneFactorMessageTypes()
+        }
+      };
+
+      const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal(null);
+    });
+
+    it('should get guardian phone factor message types', async () => {
+      const auth0 = {
+        guardian: {
+          getPhoneFactorMessageTypes: () => ({ message_types: [ 'sms', 'voice' ] })
+        }
+      };
+
+      const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({ message_types: [ 'sms', 'voice' ] });
+    });
+  });
+
+  describe('#processChanges', () => {
+    it('should update guardian phone factor message types', async () => {
+      const auth0 = {
+        guardian: {
+          updatePhoneFactorMessageTypes: (params, data) => {
+            expect(data).to.eql({ message_types: [ 'sms', 'voice' ] });
+            return Promise.resolve(data);
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        { guardianPhoneFactorMessageTypes: { message_types: [ 'sms', 'voice' ] } }
+      ]);
+    });
+
+    it('should skip processing if assets are empty', async () => {
+      const auth0 = {
+        guardian: {
+          updatePhoneFactorMessageTypes: () => {
+            const err = new Error('updatePhoneFactorMessageTypes() should not have been called');
+            return Promise.reject(err);
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        { guardianPhoneFactorMessageTypes: null }
+      ]);
+    });
+  });
+});

--- a/tests/auth0/handlers/guardianPhoneFactorSelectedProvider.tests.js
+++ b/tests/auth0/handlers/guardianPhoneFactorSelectedProvider.tests.js
@@ -1,0 +1,68 @@
+const { expect } = require('chai');
+const guardianPhoneFactorSelectedProvider = require('../../../src/auth0/handlers/guardianPhoneFactorSelectedProvider');
+
+describe('#guardianPhoneFactorSelectedProvider handler', () => {
+  describe('#getType', () => {
+    it('should support older version of auth0 client', async () => {
+      const auth0 = {
+        guardian: {
+          // omitting getPhoneFactorSelectedProvider()
+        }
+      };
+
+      const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal(null);
+    });
+
+    it('should get guardian phone factor selected provider', async () => {
+      const auth0 = {
+        guardian: {
+          getPhoneFactorSelectedProvider: () => ({ provider: 'twilio' })
+        }
+      };
+
+      const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({ provider: 'twilio' });
+    });
+  });
+
+  describe('#processChanges', () => {
+    it('should update guardian phone factor selected provider', async () => {
+      const auth0 = {
+        guardian: {
+          updatePhoneFactorSelectedProvider: (params, data) => {
+            expect(data).to.eql({ provider: 'twilio' });
+            return Promise.resolve(data);
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        { guardianPhoneFactorSelectedProvider: { provider: 'twilio' } }
+      ]);
+    });
+
+    it('should skip processing if assets are empty', async () => {
+      const auth0 = {
+        guardian: {
+          updatePhoneFactorSelectedProvider: () => {
+            const err = new Error('updatePhoneFactorSelectedProvider() should not have been called');
+            return Promise.reject(err);
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        { guardianPhoneFactorSelectedProvider: null }
+      ]);
+    });
+  });
+});

--- a/tests/auth0/handlers/guardianPolicies.tests.js
+++ b/tests/auth0/handlers/guardianPolicies.tests.js
@@ -1,0 +1,69 @@
+const { expect } = require('chai');
+const guardianPolicies = require('../../../src/auth0/handlers/guardianPolicies');
+
+describe('#guardianPolicies handler', () => {
+  describe('#getType', () => {
+    it('should support older version of auth0 client', async () => {
+      const auth0 = {
+        guardian: {
+          // omitting getPolicies()
+        }
+      };
+
+      const handler = new guardianPolicies.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal(null);
+    });
+
+    it('should get guardian policies', async () => {
+      const auth0 = {
+        guardian: {
+          getPolicies: () => ([ 'all-applications' ])
+        }
+      };
+
+      const handler = new guardianPolicies.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal([ 'all-applications' ]);
+    });
+  });
+
+  describe('#processChanges', () => {
+    it('should update guardian policies settings', async () => {
+      const auth0 = {
+        guardian: {
+          updatePolicies: (params, data) => {
+            expect(data).to.be.an('array');
+            expect(data[0]).to.equal('all-applications');
+            return Promise.resolve(data);
+          }
+        }
+      };
+
+      const handler = new guardianPolicies.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        { guardianPolicies: [ 'all-applications' ] }
+      ]);
+    });
+
+    it('should skip processing if assets are empty', async () => {
+      const auth0 = {
+        guardian: {
+          updatePolicies: () => {
+            const err = new Error('updatePolicies() should not have been called');
+            return Promise.reject(err);
+          }
+        }
+      };
+
+      const handler = new guardianPolicies.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [
+        { guardianPolicies: null }
+      ]);
+    });
+  });
+});

--- a/tests/auth0/validator.tests.js
+++ b/tests/auth0/validator.tests.js
@@ -383,6 +383,20 @@ describe('#schema validation tests', () => {
     });
   });
 
+  describe('#guardianPhoneFactorSelectedProvider validate', () => {
+    it('should fail validation if no "provider" provided', (done) => {
+      const data = {};
+
+      checkRequired('provider', { guardianPhoneFactorSelectedProvider: data }, done);
+    });
+
+    it('should pass validation', (done) => {
+      const data = { provider: 'twilio' };
+
+      checkPassed({ guardianPhoneFactorSelectedProvider: data }, done);
+    });
+  });
+
   describe('#pages validate', () => {
     it('should fail validation if no "name" provided', (done) => {
       const data = [ {

--- a/tests/auth0/validator.tests.js
+++ b/tests/auth0/validator.tests.js
@@ -397,6 +397,20 @@ describe('#schema validation tests', () => {
     });
   });
 
+  describe('#guardianPhoneFactorMessageTypes validate', () => {
+    it('should fail validation if no "message_types" provided', (done) => {
+      const data = {};
+
+      checkRequired('message_types', { guardianPhoneFactorMessageTypes: data }, done);
+    });
+
+    it('should pass validation', (done) => {
+      const data = { message_types: [ 'sms', 'voice' ] };
+
+      checkPassed({ guardianPhoneFactorMessageTypes: data }, done);
+    });
+  });
+
   describe('#pages validate', () => {
     it('should fail validation if no "name" provided', (done) => {
       const data = [ {

--- a/tests/auth0/validator.tests.js
+++ b/tests/auth0/validator.tests.js
@@ -359,6 +359,30 @@ describe('#schema validation tests', () => {
     });
   });
 
+  describe('#guardianPolicies validate', () => {
+    it('should fail validation if guardianPolicies is not an array of strings', (done) => {
+      const data = [ {
+        anything: 'anything'
+      } ];
+
+      const auth0 = new Auth0({}, { guardianPolicies: data }, {});
+
+      auth0.validate().then(failedCb(done), passedCb(done, 'should be string'));
+    });
+
+    it('should pass validation', (done) => {
+      const data = [ 'all-applications' ];
+
+      checkPassed({ guardianPolicies: data }, done);
+    });
+
+    it('should allow empty array', (done) => {
+      const data = [];
+
+      checkPassed({ guardianPolicies: data }, done);
+    });
+  });
+
   describe('#pages validate', () => {
     it('should fail validation if no "name" provided', (done) => {
       const data = [ {


### PR DESCRIPTION
## ✏️ Changes

Add support for three guardian/MFA-related features:
- Guardian Policies
- Guardian Phone factor selected provider
- Guardian Phone factor message types

⚠️ Soft dependency on https://github.com/auth0/node-auth0/pull/501 (this PR is backwards compatible with older version of `node-auth0`)
  
## 📷 Screenshots
 
🚫 
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/MFA-311
  
## 🎯 Testing
  
This has been tested after being integrated with https://github.com/auth0/auth0-deploy-cli/pull/252.
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time

