### PR TITLE
feat(migrations): add support for migrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -174,21 +174,21 @@
     },
     "@types/babel-types": {
       "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
-      "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/babel-types/-/babel-types-7.0.7.tgz",
+      "integrity": "sha1-Zn6xZA6AOUNgKAVXN9K5mG7jNuM="
     },
     "@types/babylon": {
       "version": "6.16.5",
-      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
-      "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/babylon/-/babylon-6.16.5.tgz",
+      "integrity": "sha1-HFZB22nrjN83jt0ltL53VL7rSLQ=",
       "requires": {
         "@types/babel-types": "*"
       }
     },
     "@types/body-parser": {
       "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha1-BoWzxH6zAG/+0RfN1VFkth+AU48=",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -196,67 +196,74 @@
     },
     "@types/connect": {
       "version": "3.4.33",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha1-MWEMkB7KVzuHE8MzCrxua59YhUY=",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+      "version": "4.17.6",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha1-a85J5JVwUHuG6hsHuAbwRpf6xF4=",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-jwt": {
       "version": "0.0.42",
-      "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
-      "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+      "integrity": "sha1-TwTh+t+dGHJZUNwEGAikpK339a4=",
       "requires": {
         "@types/express": "*",
         "@types/express-unless": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
-      "integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
+      "version": "4.17.8",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
+      "integrity": "sha1-uPe3FBOFNnQtoiKDmJLiA99WnRw=",
       "requires": {
         "@types/node": "*",
+        "@types/qs": "*",
         "@types/range-parser": "*"
       }
     },
     "@types/express-unless": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
-      "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-unless/-/express-unless-0.5.1.tgz",
+      "integrity": "sha1-T0QLkF5Cu/Uzgrgge8M33F/5/R8=",
       "requires": {
         "@types/express": "*"
       }
     },
     "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+      "version": "2.0.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/mime/-/mime-2.0.2.tgz",
+      "integrity": "sha1-hXoRjYY0yEu6euFAiORQhJDNXaU="
     },
     "@types/node": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+      "version": "14.0.14",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/node/-/node-14.0.14.tgz",
+      "integrity": "sha1-JKC1lZ8WrBQa6wxbPNehW3xky84="
+    },
+    "@types/qs": {
+      "version": "6.9.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha1-t1Wgk0VkogDT79+IVG7JPDaavQM="
     },
     "@types/range-parser": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
     },
     "@types/serve-static": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "version": "1.13.4",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/serve-static/-/serve-static-1.13.4.tgz",
+      "integrity": "sha1-ZmKpNYPlpsq8obI1kuuR4S+oDnw=",
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
@@ -269,7 +276,7 @@
     },
     "acorn-globals": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "requires": {
         "acorn": "^4.0.4"
@@ -277,7 +284,7 @@
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn/-/acorn-4.0.13.tgz",
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         }
       }
@@ -293,8 +300,8 @@
     },
     "agent-base": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -318,7 +325,7 @@
     },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
         "kind-of": "^3.0.2",
@@ -415,20 +422,20 @@
     },
     "asap": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
@@ -445,13 +452,13 @@
       "optional": true
     },
     "ast-types": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
-      "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA=="
+      "version": "0.13.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ast-types/-/ast-types-0.13.3.tgz",
+      "integrity": "sha1-UNo/KNF728eWmjotg6DkpyrnVac="
     },
     "async": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/async/-/async-2.1.2.tgz",
       "integrity": "sha1-YSpKtF70KnDN6Aa62G7m2wR+g4U=",
       "requires": {
         "lodash": "^4.14.0"
@@ -466,7 +473,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
@@ -477,46 +484,47 @@
       "optional": true
     },
     "auth0": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.24.0.tgz",
-      "integrity": "sha512-Z9ElyPGw52/IXOOc4enm1c6M6Ab5wfDG/3LdTiq5jGhT4ZRfkaQtuS9tAvYeCm+j3A4UpTRBjaybCvBELcR2Vg==",
+      "version": "2.27.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/auth0/-/auth0-2.27.0.tgz",
+      "integrity": "sha1-YTti5c29ppVkXcYy+IwwwOe3O5I=",
       "requires": {
+        "axios": "^0.19.2",
         "bluebird": "^3.5.5",
+        "form-data": "^3.0.0",
         "jsonwebtoken": "^8.5.1",
-        "jwks-rsa": "^1.7.0",
+        "jwks-rsa": "^1.8.0",
         "lru-memoizer": "^2.1.0",
         "object.assign": "^4.1.0",
-        "request": "^2.88.0",
         "rest-facade": "^1.12.0",
         "retry": "^0.12.0"
       },
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "jwks-rsa": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.7.0.tgz",
-          "integrity": "sha512-tq7DVJt9J6wTvl9+AQfwZIiPSuY2Vf0F+MovfRTFuBqLB1xgDVhegD33ChEAQ6yBv9zFvUIyj4aiwrSA5VehUw==",
+          "version": "1.8.1",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwks-rsa/-/jwks-rsa-1.8.1.tgz",
+          "integrity": "sha1-N1xipQxMqAWtW9aCwSyKaV3hPd8=",
           "requires": {
             "@types/express-jwt": "0.0.42",
+            "axios": "^0.19.2",
             "debug": "^4.1.0",
             "jsonwebtoken": "^8.5.1",
-            "limiter": "^1.1.4",
-            "lru-memoizer": "^2.0.1",
-            "ms": "^2.1.2",
-            "request": "^2.88.0"
+            "limiter": "^1.1.5",
+            "lru-memoizer": "^2.1.2",
+            "ms": "^2.1.2"
           }
         },
         "lru-memoizer": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.0.tgz",
-          "integrity": "sha512-oKjxgJhL+m1wfEkez7/a6iyRZUdohej+2u04qCaAQ7BBfx/qD4RH3jOQhPsd8Y3pcm7IhcNtE3kCEIDCMPiJFQ==",
+          "version": "2.1.2",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-memoizer/-/lru-memoizer-2.1.2.tgz",
+          "integrity": "sha1-XGtDZZx4rQ6eZb+BqeXvHuEJot0=",
           "requires": {
             "lodash.clonedeep": "^4.5.0",
             "lru-cache": "~4.0.0"
@@ -524,18 +532,18 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "auth0-extension-tools": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/auth0-extension-tools/-/auth0-extension-tools-1.4.4.tgz",
-      "integrity": "sha512-K1pJ8VvqdZWu2WeKYiYVVdH+bNhRWCdglqcCicGSjX7xulT8ZdpmlL6Pku772jHfBjpNE5vcCXt/mTfByU/ncg==",
+      "version": "1.5.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/auth0-extension-tools/-/auth0-extension-tools-1.5.0.tgz",
+      "integrity": "sha1-kinFtOiZT4csTPGp1ijfmwj3lPI=",
       "requires": {
         "async": "2.1.2",
-        "auth0": "^2.18.0",
+        "auth0": "^2.23.0",
         "bluebird": "^3.4.1",
         "jsonwebtoken": "^8.3.0",
         "jwks-rsa": "1.2.0",
@@ -550,20 +558,28 @@
       "dependencies": {
         "lodash": {
           "version": "4.17.13",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-          "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash/-/lodash-4.17.13.tgz",
+          "integrity": "sha1-C9w6atyHPS9ODEusKF35G2T8e5M="
         }
       }
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+      "version": "1.10.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha1-oXs6jqgRBg501H0wYSJACtRJeuI="
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -1409,7 +1425,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
           "dev": true,
           "optional": true
         }
@@ -1417,7 +1434,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -1432,13 +1449,13 @@
     },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
     },
     "boom": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/boom/-/boom-7.3.0.tgz",
+      "integrity": "sha1-czptlW0zsLGZnaP+bBKZaVDQF7k=",
       "requires": {
         "hoek": "6.x.x"
       }
@@ -1481,7 +1498,7 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
@@ -1498,8 +1515,8 @@
     },
     "bytes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1536,7 +1553,7 @@
     },
     "camel-case": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/camel-case/-/camel-case-1.2.2.tgz",
       "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
       "requires": {
         "sentence-case": "^1.1.1",
@@ -1545,7 +1562,7 @@
     },
     "camelcase": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
     "caniuse-lite": {
@@ -1555,12 +1572,12 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
         "align-text": "^0.1.3",
@@ -1594,7 +1611,7 @@
     },
     "change-case": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/change-case/-/change-case-2.3.1.tgz",
       "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
       "requires": {
         "camel-case": "^1.1.1",
@@ -1617,7 +1634,7 @@
     },
     "character-parser": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/character-parser/-/character-parser-2.2.0.tgz",
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "requires": {
         "is-regex": "^1.0.3"
@@ -1693,8 +1710,8 @@
     },
     "clean-css": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
       "requires": {
         "source-map": "~0.6.0"
       }
@@ -1716,7 +1733,7 @@
     },
     "cliui": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
         "center-align": "^0.1.1",
@@ -1762,8 +1779,8 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1799,7 +1816,7 @@
     },
     "constant-case": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/constant-case/-/constant-case-1.1.2.tgz",
       "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
       "requires": {
         "snake-case": "^1.1.0",
@@ -1808,8 +1825,8 @@
     },
     "constantinople": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
-      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/constantinople/-/constantinople-3.1.2.tgz",
+      "integrity": "sha1-1F7XJPV9PRBQABen06iJwTga5kc=",
       "requires": {
         "@types/babel-types": "^7.0.0",
         "@types/babylon": "^6.16.2",
@@ -1834,8 +1851,8 @@
     },
     "cookiejar": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha1-3YojVTB1L5iPmghE8/xYnjERElw="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -1884,7 +1901,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -1892,8 +1909,8 @@
     },
     "data-uri-to-buffer": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
+      "integrity": "sha1-dxY+qcINhkG0cH6PGKvfmnjzSDU="
     },
     "debug": {
       "version": "2.6.9",
@@ -1912,7 +1929,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
@@ -1938,8 +1955,8 @@
     },
     "deepmerge": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
-      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha1-08R/1vOpPVF7FEJrBiihewEl9fc="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -2003,7 +2020,7 @@
     },
     "degenerator": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/degenerator/-/degenerator-1.0.4.tgz",
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "requires": {
         "ast-types": "0.x.x",
@@ -2027,12 +2044,12 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "detect-indent": {
@@ -2061,12 +2078,12 @@
     },
     "doctypes": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "dot-case": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/dot-case/-/dot-case-1.1.2.tgz",
       "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
       "requires": {
         "sentence-case": "^1.1.2"
@@ -2082,7 +2099,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -2091,8 +2108,8 @@
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2104,7 +2121,7 @@
     },
     "err-code": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/err-code/-/err-code-1.1.2.tgz",
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
     },
     "error-ex": {
@@ -2142,12 +2159,12 @@
     },
     "es6-promise": {
       "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -2159,9 +2176,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "version": "1.14.3",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha1-TnuB+6YVgdyXWC7XjKt/Do1j9QM=",
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -2172,8 +2189,8 @@
       "dependencies": {
         "esprima": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
         }
       }
     },
@@ -2384,7 +2401,7 @@
     },
     "esprima": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "esquery": {
@@ -2437,8 +2454,8 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2486,7 +2503,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "eyes": {
@@ -2530,8 +2547,8 @@
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -2597,6 +2614,24 @@
         "write": "^0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2605,23 +2640,23 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "3.0.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha1-MbfjnIXxNVtxOe4MZHzw3n+DxoI=",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
     "formidable": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha1-v2muopcpgmdfAIZTQrmCmG9rjdk="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3209,7 +3244,7 @@
     },
     "ftp": {
       "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ftp/-/ftp-0.3.10.tgz",
       "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
       "requires": {
         "readable-stream": "1.1.x",
@@ -3218,12 +3253,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3234,7 +3269,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -3258,8 +3293,8 @@
     },
     "get-uri": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
-      "integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/get-uri/-/get-uri-2.0.4.tgz",
+      "integrity": "sha1-1JN6uBniGNTLWuGOT1livvFpzGo=",
       "requires": {
         "data-uri-to-buffer": "1",
         "debug": "2",
@@ -3278,7 +3313,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -3383,13 +3418,13 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -3494,8 +3529,8 @@
     },
     "hoek": {
       "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha1-c7fTOVLgH+J6OLBFcpS3ndjaJCw="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -3515,8 +3550,8 @@
     },
     "http-errors": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha1-bGGeT5xgMIw4UZSYwU+7EKrOuwY=",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
@@ -3527,15 +3562,15 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
         }
       }
     },
     "http-proxy-agent": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -3543,8 +3578,8 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -3553,7 +3588,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -3563,8 +3598,8 @@
     },
     "https-proxy-agent": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha1-uMKGQz6HYCMRsByOo0QT2Fakr4E=",
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
@@ -3572,16 +3607,16 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
@@ -3652,7 +3687,7 @@
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-accessor-descriptor": {
@@ -3757,7 +3792,7 @@
     },
     "is-expression": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-expression/-/is-expression-3.0.0.tgz",
       "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
       "requires": {
         "acorn": "~4.0.2",
@@ -3766,7 +3801,7 @@
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn/-/acorn-4.0.13.tgz",
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         }
       }
@@ -3812,7 +3847,7 @@
     },
     "is-lower-case": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-lower-case/-/is-lower-case-1.1.3.tgz",
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "requires": {
         "lower-case": "^1.1.0"
@@ -3910,12 +3945,12 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-upper-case": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-upper-case/-/is-upper-case-1.1.2.tgz",
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "requires": {
         "upper-case": "^1.1.0"
@@ -4116,7 +4151,7 @@
     },
     "js-stringify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
     },
     "js-tokens": {
@@ -4144,7 +4179,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
@@ -4154,7 +4189,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -4170,7 +4205,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
@@ -4181,8 +4216,8 @@
     },
     "jsonwebtoken": {
       "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -4198,14 +4233,14 @@
       "dependencies": {
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -4216,7 +4251,7 @@
     },
     "jstransformer": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jstransformer/-/jstransformer-1.0.0.tgz",
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
       "requires": {
         "is-promise": "^2.0.0",
@@ -4225,8 +4260,8 @@
     },
     "jwa": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -4235,7 +4270,7 @@
     },
     "jwks-rsa": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.2.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwks-rsa/-/jwks-rsa-1.2.0.tgz",
       "integrity": "sha1-t+kluerAcirYY0rWp+l8fa7T1Mg=",
       "requires": {
         "@types/express-jwt": "0.0.34",
@@ -4248,7 +4283,7 @@
       "dependencies": {
         "@types/express-jwt": {
           "version": "0.0.34",
-          "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.34.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-jwt/-/express-jwt-0.0.34.tgz",
           "integrity": "sha1-/b7kxq9cCiRu8qkz9VGZc8dxfwI=",
           "requires": {
             "@types/express": "*",
@@ -4259,8 +4294,8 @@
     },
     "jws": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -4276,7 +4311,7 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "levn": {
@@ -4290,8 +4325,8 @@
     },
     "limiter": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
-      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha1-j5KiWzsWxhMSk6DMg0tKg4oqp8I="
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -4325,7 +4360,7 @@
     },
     "lock": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lock/-/lock-0.1.4.tgz",
       "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
     },
     "lodash": {
@@ -4335,52 +4370,52 @@
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "longest": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
@@ -4393,12 +4428,12 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lower-case-first": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lower-case-first/-/lower-case-first-1.0.2.tgz",
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "requires": {
         "lower-case": "^1.1.2"
@@ -4415,7 +4450,7 @@
     },
     "lru-memoizer": {
       "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-1.11.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-memoizer/-/lru-memoizer-1.11.2.tgz",
       "integrity": "sha1-XcDIBrWEHBThDAVBnw9+wSH76aQ=",
       "requires": {
         "lock": "~0.1.2",
@@ -4450,7 +4485,7 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
@@ -4477,20 +4512,20 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.44.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "mimic-fn": {
@@ -4640,7 +4675,7 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
@@ -4713,7 +4748,7 @@
     },
     "netmask": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/netmask/-/netmask-1.0.6.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "next-tick": {
@@ -4729,7 +4764,7 @@
     },
     "node-uuid": {
       "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "normalize-package-data": {
@@ -4919,7 +4954,8 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "",
+              "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
@@ -5326,7 +5362,8 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "",
+              "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
@@ -6276,7 +6313,8 @@
         },
         "set-value": {
           "version": "2.0.0",
-          "resolved": "",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/set-value/-/set-value-2.0.0.tgz",
+          "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
           "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -6419,7 +6457,8 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "",
+              "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
@@ -6614,7 +6653,8 @@
         },
         "union-value": {
           "version": "1.0.0",
-          "resolved": "",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/union-value/-/union-value-1.0.0.tgz",
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "dev": true,
           "requires": {
             "arr-union": "^3.1.0",
@@ -6703,7 +6743,8 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": "",
+              "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
               "dev": true
             }
           }
@@ -6878,8 +6919,8 @@
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -7088,8 +7129,8 @@
     },
     "pac-proxy-agent": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
+      "integrity": "sha1-EVseWPkldsrC66cYWTynsON94q0=",
       "requires": {
         "agent-base": "^4.2.0",
         "debug": "^4.1.1",
@@ -7103,23 +7144,23 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "pac-resolver": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pac-resolver/-/pac-resolver-3.0.0.tgz",
+      "integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
       "requires": {
         "co": "^4.6.0",
         "degenerator": "^1.0.4",
@@ -7130,7 +7171,7 @@
     },
     "param-case": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/param-case/-/param-case-1.1.2.tgz",
       "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
       "requires": {
         "sentence-case": "^1.1.2"
@@ -7160,7 +7201,7 @@
     },
     "pascal-case": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pascal-case/-/pascal-case-1.1.2.tgz",
       "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
       "requires": {
         "camel-case": "^1.1.1",
@@ -7176,7 +7217,7 @@
     },
     "path-case": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-case/-/path-case-1.1.2.tgz",
       "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
       "requires": {
         "sentence-case": "^1.1.2"
@@ -7235,7 +7276,7 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
@@ -7341,8 +7382,8 @@
     },
     "promise": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -7399,7 +7440,7 @@
     },
     "promise-retry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/promise-retry/-/promise-retry-1.1.1.tgz",
       "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "requires": {
         "err-code": "^1.0.0",
@@ -7408,15 +7449,15 @@
       "dependencies": {
         "retry": {
           "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/retry/-/retry-0.10.1.tgz",
           "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
         }
       }
     },
     "proxy-agent": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.1.tgz",
-      "integrity": "sha512-WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/proxy-agent/-/proxy-agent-3.1.1.tgz",
+      "integrity": "sha1-fgTga/Nq+mJKFUC+JHtHyXC9MBQ=",
       "requires": {
         "agent-base": "^4.2.0",
         "debug": "4",
@@ -7430,36 +7471,36 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "lru-cache": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
           "requires": {
             "yallist": "^3.0.2"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "yallist": {
           "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0="
         }
       }
     },
     "proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -7467,14 +7508,14 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+      "version": "1.8.0",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ="
     },
     "pug": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
-      "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug/-/pug-2.0.4.tgz",
+      "integrity": "sha1-7naC7ApgSUs41IqI8F87CskxN30=",
       "requires": {
         "pug-code-gen": "^2.0.2",
         "pug-filters": "^3.1.1",
@@ -7488,8 +7529,8 @@
     },
     "pug-attrs": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
-      "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-attrs/-/pug-attrs-2.0.4.tgz",
+      "integrity": "sha1-svRMQ55OtK1dTvJcrCDRitKMwzY=",
       "requires": {
         "constantinople": "^3.0.1",
         "js-stringify": "^1.0.1",
@@ -7498,8 +7539,8 @@
     },
     "pug-code-gen": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.2.tgz",
-      "integrity": "sha512-kROFWv/AHx/9CRgoGJeRSm+4mLWchbgpRzTEn8XCiwwOy6Vh0gAClS8Vh5TEJ9DBjaP8wCjS3J6HKsEsYdvaCw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-code-gen/-/pug-code-gen-2.0.2.tgz",
+      "integrity": "sha1-rQlnFirqB33PeHg42U7RSssCF8I=",
       "requires": {
         "constantinople": "^3.1.2",
         "doctypes": "^1.1.0",
@@ -7513,13 +7554,13 @@
     },
     "pug-error": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
-      "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-error/-/pug-error-1.3.3.tgz",
+      "integrity": "sha1-80L7AIdS1YA0wYXeA2At2f/hX6Y="
     },
     "pug-filters": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
-      "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-filters/-/pug-filters-3.1.1.tgz",
+      "integrity": "sha1-qyzILbnuzPV4vaiRMOJSoNsCaqc=",
       "requires": {
         "clean-css": "^4.1.11",
         "constantinople": "^3.0.1",
@@ -7532,8 +7573,8 @@
     },
     "pug-lexer": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
-      "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-lexer/-/pug-lexer-4.1.0.tgz",
+      "integrity": "sha1-UxzeSMfAsfy7wrhUhchmXjFInP0=",
       "requires": {
         "character-parser": "^2.1.1",
         "is-expression": "^3.0.0",
@@ -7542,8 +7583,8 @@
     },
     "pug-linker": {
       "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
-      "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-linker/-/pug-linker-3.0.6.tgz",
+      "integrity": "sha1-9b8hiw79Zc5mcPevxRZY0Pgpifs=",
       "requires": {
         "pug-error": "^1.3.3",
         "pug-walk": "^1.1.8"
@@ -7551,8 +7592,8 @@
     },
     "pug-load": {
       "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
-      "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-load/-/pug-load-2.0.12.tgz",
+      "integrity": "sha1-04yF64X24vcE3qFNzKlBRNNdPns=",
       "requires": {
         "object-assign": "^4.1.0",
         "pug-walk": "^1.1.8"
@@ -7560,8 +7601,8 @@
     },
     "pug-parser": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
-      "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-parser/-/pug-parser-5.0.1.tgz",
+      "integrity": "sha1-A+etpItoQL04Ivhn19kPhC0P/ck=",
       "requires": {
         "pug-error": "^1.3.3",
         "token-stream": "0.0.1"
@@ -7569,21 +7610,21 @@
     },
     "pug-runtime": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
-      "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-runtime/-/pug-runtime-2.0.5.tgz",
+      "integrity": "sha1-baeXbDa/IvaOczw1kkDYrnoylTo="
     },
     "pug-strip-comments": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
-      "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
+      "integrity": "sha1-zBtt4fbo9ZMc8C7GbN/9P1Dq+Kg=",
       "requires": {
         "pug-error": "^1.3.3"
       }
     },
     "pug-walk": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
-      "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-walk/-/pug-walk-1.1.8.tgz",
+      "integrity": "sha1-tAj2fyeRL4wh2i9FtyMMS9Kl6no="
     },
     "punycode": {
       "version": "2.1.1",
@@ -7591,9 +7632,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "version": "6.9.4",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha1-kJCykNH5FyjTwi5UhDykSupatoc="
     },
     "randomatic": {
       "version": "3.1.1",
@@ -7625,8 +7666,8 @@
     },
     "raw-body": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/raw-body/-/raw-body-2.4.1.tgz",
+      "integrity": "sha1-MKyC+Yu1rowVLmcUnayNVRU7Fow=",
       "requires": {
         "bytes": "3.1.0",
         "http-errors": "1.7.3",
@@ -7636,8 +7677,8 @@
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -8086,8 +8127,8 @@
     },
     "request": {
       "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/request/-/request-2.88.2.tgz",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -8111,10 +8152,25 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+        },
         "uuid": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
         }
       }
     },
@@ -8157,8 +8213,8 @@
     },
     "rest-facade": {
       "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/rest-facade/-/rest-facade-1.12.0.tgz",
-      "integrity": "sha512-LsrzWP+aAy8LWwAi1ZshecO7nOWWZB9bB4gJTwXLl5DS40D5vmmdupKvqEcz8m0GUybLI3uJX8bofJtSrs5Acw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/rest-facade/-/rest-facade-1.12.0.tgz",
+      "integrity": "sha1-5qJZWLNLqyMjr1qVPAE1rCaE03E=",
       "requires": {
         "change-case": "^2.3.0",
         "deepmerge": "^3.2.0",
@@ -8169,21 +8225,31 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
           }
         },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         },
         "superagent": {
           "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-          "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent/-/superagent-3.8.3.tgz",
+          "integrity": "sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=",
           "requires": {
             "component-emitter": "^1.2.0",
             "cookiejar": "^2.1.0",
@@ -8218,12 +8284,12 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
         "align-text": "^0.1.1"
@@ -8288,7 +8354,7 @@
     },
     "sentence-case": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/sentence-case/-/sentence-case-1.1.3.tgz",
       "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
       "requires": {
         "lower-case": "^1.1.1"
@@ -8321,8 +8387,8 @@
     },
     "setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -8362,12 +8428,12 @@
     },
     "smart-buffer": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha1-kWBcJdkWUvRmHqacz0XxszHKIbo="
     },
     "snake-case": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/snake-case/-/snake-case-1.1.2.tgz",
       "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
       "requires": {
         "sentence-case": "^1.1.2"
@@ -8475,7 +8541,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
           "dev": true,
           "optional": true
         }
@@ -8493,8 +8560,8 @@
     },
     "socks": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
-      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/socks/-/socks-2.3.3.tgz",
+      "integrity": "sha1-ARKfCl1TTSuJdxLtis6rfuZdeOM=",
       "requires": {
         "ip": "1.1.5",
         "smart-buffer": "^4.1.0"
@@ -8502,8 +8569,8 @@
     },
     "socks-proxy-agent": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+      "integrity": "sha1-PImR8xRbJ5nnDhG9X7yLGWMRY4Y=",
       "requires": {
         "agent-base": "~4.2.1",
         "socks": "~2.3.2"
@@ -8511,8 +8578,8 @@
       "dependencies": {
         "agent-base": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agent-base/-/agent-base-4.2.1.tgz",
+          "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
           "requires": {
             "es6-promisify": "^5.0.0"
           }
@@ -8595,8 +8662,8 @@
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -8639,7 +8706,7 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-width": {
@@ -8683,8 +8750,8 @@
     },
     "superagent": {
       "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.1.tgz",
-      "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent/-/superagent-3.8.1.tgz",
+      "integrity": "sha1-JXH9kh8/zbpDrGjDs1yRlRUycB8=",
       "requires": {
         "component-emitter": "^1.2.0",
         "cookiejar": "^2.1.0",
@@ -8700,23 +8767,33 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
           }
         },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
     "superagent-proxy": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-2.0.0.tgz",
-      "integrity": "sha512-TktJma5jPdiH1BNN+reF/RMW3b8aBTCV7KlLFV0uYcREgNf3pvo7Rdt564OcFHwkGb3mYEhHuWPBhSbOwiNaYw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent-proxy/-/superagent-proxy-2.0.0.tgz",
+      "integrity": "sha1-n1dRXNZg4unOVcDmvXD5LrB8PuA=",
       "requires": {
         "debug": "^3.1.0",
         "proxy-agent": "3"
@@ -8724,16 +8801,16 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
         }
       }
     },
@@ -8748,7 +8825,7 @@
     },
     "swap-case": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/swap-case/-/swap-case-1.1.2.tgz",
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "requires": {
         "lower-case": "^1.1.1",
@@ -8834,12 +8911,12 @@
     },
     "thunkify": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/thunkify/-/thunkify-2.1.2.tgz",
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
     },
     "title-case": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/title-case/-/title-case-1.1.2.tgz",
       "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
       "requires": {
         "sentence-case": "^1.1.1",
@@ -8908,18 +8985,18 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
     },
     "token-stream": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/token-stream/-/token-stream-0.0.1.tgz",
       "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -8933,7 +9010,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -8941,7 +9018,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
@@ -8966,7 +9043,7 @@
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
         "source-map": "~0.5.1",
@@ -8976,14 +9053,14 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
@@ -9002,7 +9079,7 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
@@ -9051,12 +9128,12 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "upper-case-first": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/upper-case-first/-/upper-case-first-1.1.2.tgz",
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "requires": {
         "upper-case": "^1.1.1"
@@ -9116,7 +9193,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -9126,18 +9203,18 @@
     },
     "very-fast-args": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/very-fast-args/-/very-fast-args-1.1.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/very-fast-args/-/very-fast-args-1.1.0.tgz",
       "integrity": "sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y="
     },
     "void-elements": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
     },
     "webtask-tools": {
       "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/webtask-tools/-/webtask-tools-3.4.1.tgz",
-      "integrity": "sha512-NqjvLZVA3AUsRLWBIEcNH7jEoBZERjb1w3JANg/KjxUkEcmS+c8bcBPAGIy+awhgVax2E52qs6bZhiPg842aCw==",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/webtask-tools/-/webtask-tools-3.4.1.tgz",
+      "integrity": "sha1-IkPvDlgymSpgjuaRJQljj0ZQTIQ=",
       "requires": {
         "boom": "^7.2.0",
         "jsonwebtoken": "^5.7.0",
@@ -9148,22 +9225,32 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "requires": {
             "ms": "^2.1.1"
           },
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+              "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
             }
+          }
+        },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
           }
         },
         "jsonwebtoken": {
           "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
           "integrity": "sha1-HJD5qGzlt0j1+XnBK3BAK0r83bQ=",
           "requires": {
             "jws": "^3.0.0",
@@ -9173,13 +9260,13 @@
         },
         "ms": {
           "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-0.7.3.tgz",
           "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
         },
         "superagent": {
           "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-          "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent/-/superagent-3.8.3.tgz",
+          "integrity": "sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=",
           "requires": {
             "component-emitter": "^1.2.0",
             "cookiejar": "^2.1.0",
@@ -9206,7 +9293,7 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
     },
     "winston": {
@@ -9231,7 +9318,7 @@
     },
     "with": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/with/-/with-5.1.1.tgz",
       "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
       "requires": {
         "acorn": "^3.1.0",
@@ -9259,13 +9346,13 @@
     },
     "xregexp": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/xregexp/-/xregexp-2.0.0.tgz",
       "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
     },
     "yallist": {
       "version": "2.1.2",
@@ -9274,7 +9361,7 @@
     },
     "yargs": {
       "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
         "camelcase": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,21 +174,21 @@
     },
     "@types/babel-types": {
       "version": "7.0.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/babel-types/-/babel-types-7.0.7.tgz",
-      "integrity": "sha1-Zn6xZA6AOUNgKAVXN9K5mG7jNuM="
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
+      "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ=="
     },
     "@types/babylon": {
       "version": "6.16.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/babylon/-/babylon-6.16.5.tgz",
-      "integrity": "sha1-HFZB22nrjN83jt0ltL53VL7rSLQ=",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
+      "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
       "requires": {
         "@types/babel-types": "*"
       }
     },
     "@types/body-parser": {
       "version": "1.19.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha1-BoWzxH6zAG/+0RfN1VFkth+AU48=",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -196,16 +196,16 @@
     },
     "@types/connect": {
       "version": "3.4.33",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha1-MWEMkB7KVzuHE8MzCrxua59YhUY=",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
+      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/express": {
       "version": "4.17.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express/-/express-4.17.6.tgz",
-      "integrity": "sha1-a85J5JVwUHuG6hsHuAbwRpf6xF4=",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
@@ -215,8 +215,8 @@
     },
     "@types/express-jwt": {
       "version": "0.0.42",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-jwt/-/express-jwt-0.0.42.tgz",
-      "integrity": "sha1-TwTh+t+dGHJZUNwEGAikpK339a4=",
+      "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+      "integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
       "requires": {
         "@types/express": "*",
         "@types/express-unless": "*"
@@ -224,8 +224,8 @@
     },
     "@types/express-serve-static-core": {
       "version": "4.17.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
-      "integrity": "sha1-uPe3FBOFNnQtoiKDmJLiA99WnRw=",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.8.tgz",
+      "integrity": "sha512-1SJZ+R3Q/7mLkOD9ewCBDYD2k0WyZQtWYqF/2VvoNN2/uhI49J9CDN4OAm+wGMA0DbArA4ef27xl4+JwMtGggw==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -234,36 +234,36 @@
     },
     "@types/express-unless": {
       "version": "0.5.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-unless/-/express-unless-0.5.1.tgz",
-      "integrity": "sha1-T0QLkF5Cu/Uzgrgge8M33F/5/R8=",
+      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
+      "integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
       "requires": {
         "@types/express": "*"
       }
     },
     "@types/mime": {
       "version": "2.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/mime/-/mime-2.0.2.tgz",
-      "integrity": "sha1-hXoRjYY0yEu6euFAiORQhJDNXaU="
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
+      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q=="
     },
     "@types/node": {
       "version": "14.0.14",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha1-JKC1lZ8WrBQa6wxbPNehW3xky84="
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
+      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ=="
     },
     "@types/qs": {
       "version": "6.9.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/qs/-/qs-6.9.3.tgz",
-      "integrity": "sha1-t1Wgk0VkogDT79+IVG7JPDaavQM="
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/serve-static": {
       "version": "1.13.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/serve-static/-/serve-static-1.13.4.tgz",
-      "integrity": "sha1-ZmKpNYPlpsq8obI1kuuR4S+oDnw=",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
+      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
@@ -276,7 +276,7 @@
     },
     "acorn-globals": {
       "version": "3.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn-globals/-/acorn-globals-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "requires": {
         "acorn": "^4.0.4"
@@ -284,7 +284,7 @@
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn/-/acorn-4.0.13.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         }
       }
@@ -300,8 +300,8 @@
     },
     "agent-base": {
       "version": "4.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -325,7 +325,7 @@
     },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
         "kind-of": "^3.0.2",
@@ -422,20 +422,20 @@
     },
     "asap": {
       "version": "2.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/asap/-/asap-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
@@ -453,12 +453,12 @@
     },
     "ast-types": {
       "version": "0.13.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ast-types/-/ast-types-0.13.3.tgz",
-      "integrity": "sha1-UNo/KNF728eWmjotg6DkpyrnVac="
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
+      "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
     },
     "async": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/async/-/async-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
       "integrity": "sha1-YSpKtF70KnDN6Aa62G7m2wR+g4U=",
       "requires": {
         "lodash": "^4.14.0"
@@ -473,7 +473,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
@@ -485,8 +485,8 @@
     },
     "auth0": {
       "version": "2.27.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/auth0/-/auth0-2.27.0.tgz",
-      "integrity": "sha1-YTti5c29ppVkXcYy+IwwwOe3O5I=",
+      "resolved": "https://registry.npmjs.org/auth0/-/auth0-2.27.0.tgz",
+      "integrity": "sha512-xDWH9uK+wc8NSoiA11pKKzInX1IlI8fHy4ViEmP5INI5Ee2cUq70QUfdvjcabOKzi6qHGqpQL5QC02Q/SLP3Tg==",
       "requires": {
         "axios": "^0.19.2",
         "bluebird": "^3.5.5",
@@ -501,16 +501,16 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "jwks-rsa": {
           "version": "1.8.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwks-rsa/-/jwks-rsa-1.8.1.tgz",
-          "integrity": "sha1-N1xipQxMqAWtW9aCwSyKaV3hPd8=",
+          "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.8.1.tgz",
+          "integrity": "sha512-CcE8ypsATHwGmzELwzeFjLzPBXTXTrMmDYbn92LTQwYsZdOedp+ZIuYTofUdrWreu8CKRuXmhk17+6/li2sR6g==",
           "requires": {
             "@types/express-jwt": "0.0.42",
             "axios": "^0.19.2",
@@ -523,8 +523,8 @@
         },
         "lru-memoizer": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-memoizer/-/lru-memoizer-2.1.2.tgz",
-          "integrity": "sha1-XGtDZZx4rQ6eZb+BqeXvHuEJot0=",
+          "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.2.tgz",
+          "integrity": "sha512-N5L5xlnVcbIinNn/TJ17vHBZwBMt9t7aJDz2n97moWubjNl6VO9Ao2XuAGBBddkYdjrwR9HfzXbT6NfMZXAZ/A==",
           "requires": {
             "lodash.clonedeep": "^4.5.0",
             "lru-cache": "~4.0.0"
@@ -532,15 +532,15 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "auth0-extension-tools": {
       "version": "1.5.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/auth0-extension-tools/-/auth0-extension-tools-1.5.0.tgz",
-      "integrity": "sha1-kinFtOiZT4csTPGp1ijfmwj3lPI=",
+      "resolved": "https://registry.npmjs.org/auth0-extension-tools/-/auth0-extension-tools-1.5.0.tgz",
+      "integrity": "sha512-UxQWMI/W1P5xhPUjDnbibyUyjoKYRmZCqIPFZs7tMFKNIugBfRV72tk0mX3fEkvbqjujwvpsS5a1a7jUqAZmFQ==",
       "requires": {
         "async": "2.1.2",
         "auth0": "^2.23.0",
@@ -558,25 +558,25 @@
       "dependencies": {
         "lodash": {
           "version": "4.17.13",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash/-/lodash-4.17.13.tgz",
-          "integrity": "sha1-C9w6atyHPS9ODEusKF35G2T8e5M="
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
+          "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
         }
       }
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.10.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha1-oXs6jqgRBg501H0wYSJACtRJeuI="
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "axios": {
       "version": "0.19.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "requires": {
         "follow-redirects": "1.5.10"
       }
@@ -1434,7 +1434,7 @@
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -1449,13 +1449,13 @@
     },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "boom": {
       "version": "7.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha1-czptlW0zsLGZnaP+bBKZaVDQF7k=",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
+      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
       "requires": {
         "hoek": "6.x.x"
       }
@@ -1498,7 +1498,7 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
@@ -1515,8 +1515,8 @@
     },
     "bytes": {
       "version": "3.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1553,7 +1553,7 @@
     },
     "camel-case": {
       "version": "1.2.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/camel-case/-/camel-case-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
       "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
       "requires": {
         "sentence-case": "^1.1.1",
@@ -1562,7 +1562,7 @@
     },
     "camelcase": {
       "version": "1.2.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/camelcase/-/camelcase-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
     "caniuse-lite": {
@@ -1572,12 +1572,12 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
         "align-text": "^0.1.3",
@@ -1611,7 +1611,7 @@
     },
     "change-case": {
       "version": "2.3.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/change-case/-/change-case-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
       "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
       "requires": {
         "camel-case": "^1.1.1",
@@ -1634,7 +1634,7 @@
     },
     "character-parser": {
       "version": "2.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/character-parser/-/character-parser-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "requires": {
         "is-regex": "^1.0.3"
@@ -1710,8 +1710,8 @@
     },
     "clean-css": {
       "version": "4.2.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
       "requires": {
         "source-map": "~0.6.0"
       }
@@ -1733,7 +1733,7 @@
     },
     "cliui": {
       "version": "2.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cliui/-/cliui-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
         "center-align": "^0.1.1",
@@ -1779,8 +1779,8 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1816,7 +1816,7 @@
     },
     "constant-case": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/constant-case/-/constant-case-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
       "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
       "requires": {
         "snake-case": "^1.1.0",
@@ -1825,8 +1825,8 @@
     },
     "constantinople": {
       "version": "3.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/constantinople/-/constantinople-3.1.2.tgz",
-      "integrity": "sha1-1F7XJPV9PRBQABen06iJwTga5kc=",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
+      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "requires": {
         "@types/babel-types": "^7.0.0",
         "@types/babylon": "^6.16.2",
@@ -1851,8 +1851,8 @@
     },
     "cookiejar": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha1-3YojVTB1L5iPmghE8/xYnjERElw="
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -1901,7 +1901,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -1909,8 +1909,8 @@
     },
     "data-uri-to-buffer": {
       "version": "1.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-      "integrity": "sha1-dxY+qcINhkG0cH6PGKvfmnjzSDU="
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
+      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
     },
     "debug": {
       "version": "2.6.9",
@@ -1929,7 +1929,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
@@ -1955,8 +1955,8 @@
     },
     "deepmerge": {
       "version": "3.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/deepmerge/-/deepmerge-3.3.0.tgz",
-      "integrity": "sha1-08R/1vOpPVF7FEJrBiihewEl9fc="
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -2020,7 +2020,7 @@
     },
     "degenerator": {
       "version": "1.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/degenerator/-/degenerator-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "requires": {
         "ast-types": "0.x.x",
@@ -2044,12 +2044,12 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "detect-indent": {
@@ -2078,12 +2078,12 @@
     },
     "doctypes": {
       "version": "1.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/doctypes/-/doctypes-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "dot-case": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/dot-case/-/dot-case-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
       "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
       "requires": {
         "sentence-case": "^1.1.2"
@@ -2099,7 +2099,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
         "jsbn": "~0.1.0",
@@ -2108,8 +2108,8 @@
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -2121,7 +2121,7 @@
     },
     "err-code": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/err-code/-/err-code-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
       "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
     },
     "error-ex": {
@@ -2159,12 +2159,12 @@
     },
     "es6-promise": {
       "version": "4.2.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -2177,8 +2177,8 @@
     },
     "escodegen": {
       "version": "1.14.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha1-TnuB+6YVgdyXWC7XjKt/Do1j9QM=",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -2189,8 +2189,8 @@
       "dependencies": {
         "esprima": {
           "version": "4.0.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         }
       }
     },
@@ -2401,7 +2401,7 @@
     },
     "esprima": {
       "version": "3.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/esprima/-/esprima-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
       "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "esquery": {
@@ -2454,8 +2454,8 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2503,7 +2503,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "eyes": {
@@ -2547,8 +2547,8 @@
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90="
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -2616,16 +2616,16 @@
     },
     "follow-redirects": {
       "version": "1.5.10",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
         "debug": "=3.1.0"
       },
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -2640,13 +2640,13 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha1-MbfjnIXxNVtxOe4MZHzw3n+DxoI=",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2655,8 +2655,8 @@
     },
     "formidable": {
       "version": "1.2.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha1-v2muopcpgmdfAIZTQrmCmG9rjdk="
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3244,7 +3244,7 @@
     },
     "ftp": {
       "version": "0.3.10",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ftp/-/ftp-0.3.10.tgz",
+      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
       "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
       "requires": {
         "readable-stream": "1.1.x",
@@ -3253,12 +3253,12 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3269,7 +3269,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -3293,8 +3293,8 @@
     },
     "get-uri": {
       "version": "2.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/get-uri/-/get-uri-2.0.4.tgz",
-      "integrity": "sha1-1JN6uBniGNTLWuGOT1livvFpzGo=",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-2.0.4.tgz",
+      "integrity": "sha512-v7LT/s8kVjs+Tx0ykk1I+H/rbpzkHvuIq87LmeXptcf5sNWm9uQiwjNAt94SJPA1zOlCntmnOlJvVWKmzsxG8Q==",
       "requires": {
         "data-uri-to-buffer": "1",
         "debug": "2",
@@ -3313,7 +3313,7 @@
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "^1.0.0"
@@ -3418,13 +3418,13 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -3529,8 +3529,8 @@
     },
     "hoek": {
       "version": "6.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha1-c7fTOVLgH+J6OLBFcpS3ndjaJCw="
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -3550,8 +3550,8 @@
     },
     "http-errors": {
       "version": "1.7.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-errors/-/http-errors-1.7.3.tgz",
-      "integrity": "sha1-bGGeT5xgMIw4UZSYwU+7EKrOuwY=",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
@@ -3562,15 +3562,15 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.4",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         }
       }
     },
     "http-proxy-agent": {
       "version": "2.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -3578,8 +3578,8 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -3588,7 +3588,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -3598,8 +3598,8 @@
     },
     "https-proxy-agent": {
       "version": "3.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-      "integrity": "sha1-uMKGQz6HYCMRsByOo0QT2Fakr4E=",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
@@ -3607,16 +3607,16 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -3687,7 +3687,7 @@
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ip/-/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-accessor-descriptor": {
@@ -3792,7 +3792,7 @@
     },
     "is-expression": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-expression/-/is-expression-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
       "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
       "requires": {
         "acorn": "~4.0.2",
@@ -3801,7 +3801,7 @@
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/acorn/-/acorn-4.0.13.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
         }
       }
@@ -3847,7 +3847,7 @@
     },
     "is-lower-case": {
       "version": "1.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "requires": {
         "lower-case": "^1.1.0"
@@ -3945,12 +3945,12 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-upper-case": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "requires": {
         "upper-case": "^1.1.0"
@@ -4151,7 +4151,7 @@
     },
     "js-stringify": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/js-stringify/-/js-stringify-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
     },
     "js-tokens": {
@@ -4179,7 +4179,7 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsesc": {
@@ -4189,7 +4189,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
@@ -4205,7 +4205,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
@@ -4216,8 +4216,8 @@
     },
     "jsonwebtoken": {
       "version": "8.5.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha1-AOceC431TCEhofJhN98igGc7zA0=",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -4233,14 +4233,14 @@
       "dependencies": {
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -4251,7 +4251,7 @@
     },
     "jstransformer": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jstransformer/-/jstransformer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
       "requires": {
         "is-promise": "^2.0.0",
@@ -4260,8 +4260,8 @@
     },
     "jwa": {
       "version": "1.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -4270,7 +4270,7 @@
     },
     "jwks-rsa": {
       "version": "1.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jwks-rsa/-/jwks-rsa-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.2.0.tgz",
       "integrity": "sha1-t+kluerAcirYY0rWp+l8fa7T1Mg=",
       "requires": {
         "@types/express-jwt": "0.0.34",
@@ -4283,7 +4283,7 @@
       "dependencies": {
         "@types/express-jwt": {
           "version": "0.0.34",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/@types/express-jwt/-/express-jwt-0.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.34.tgz",
           "integrity": "sha1-/b7kxq9cCiRu8qkz9VGZc8dxfwI=",
           "requires": {
             "@types/express": "*",
@@ -4294,8 +4294,8 @@
     },
     "jws": {
       "version": "3.2.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -4311,7 +4311,7 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "levn": {
@@ -4325,8 +4325,8 @@
     },
     "limiter": {
       "version": "1.1.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/limiter/-/limiter-1.1.5.tgz",
-      "integrity": "sha1-j5KiWzsWxhMSk6DMg0tKg4oqp8I="
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -4360,7 +4360,7 @@
     },
     "lock": {
       "version": "0.1.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lock/-/lock-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/lock/-/lock-0.1.4.tgz",
       "integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
     },
     "lodash": {
@@ -4370,52 +4370,52 @@
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "longest": {
       "version": "1.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/longest/-/longest-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
@@ -4428,12 +4428,12 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lower-case-first": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "requires": {
         "lower-case": "^1.1.2"
@@ -4450,7 +4450,7 @@
     },
     "lru-memoizer": {
       "version": "1.11.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-memoizer/-/lru-memoizer-1.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-1.11.2.tgz",
       "integrity": "sha1-XcDIBrWEHBThDAVBnw9+wSH76aQ=",
       "requires": {
         "lock": "~0.1.2",
@@ -4485,7 +4485,7 @@
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
@@ -4512,18 +4512,18 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.44.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I="
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -4675,7 +4675,7 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
@@ -4748,7 +4748,7 @@
     },
     "netmask": {
       "version": "1.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/netmask/-/netmask-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU="
     },
     "next-tick": {
@@ -4764,7 +4764,7 @@
     },
     "node-uuid": {
       "version": "1.4.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/node-uuid/-/node-uuid-1.4.8.tgz",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "normalize-package-data": {
@@ -6919,8 +6919,8 @@
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -7129,8 +7129,8 @@
     },
     "pac-proxy-agent": {
       "version": "3.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
-      "integrity": "sha1-EVseWPkldsrC66cYWTynsON94q0=",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-44DUg21G/liUZ48dJpUSjZnFfZro/0K5JTyFYLBcmh9+T6Ooi4/i4efwUiEy0+4oQusCBqWdhv16XohIj1GqnQ==",
       "requires": {
         "agent-base": "^4.2.0",
         "debug": "^4.1.1",
@@ -7144,23 +7144,23 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "pac-resolver": {
       "version": "3.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pac-resolver/-/pac-resolver-3.0.0.tgz",
-      "integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
+      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
       "requires": {
         "co": "^4.6.0",
         "degenerator": "^1.0.4",
@@ -7171,7 +7171,7 @@
     },
     "param-case": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/param-case/-/param-case-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
       "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
       "requires": {
         "sentence-case": "^1.1.2"
@@ -7201,7 +7201,7 @@
     },
     "pascal-case": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pascal-case/-/pascal-case-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
       "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
       "requires": {
         "camel-case": "^1.1.1",
@@ -7217,7 +7217,7 @@
     },
     "path-case": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/path-case/-/path-case-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
       "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
       "requires": {
         "sentence-case": "^1.1.2"
@@ -7276,7 +7276,7 @@
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
@@ -7382,8 +7382,8 @@
     },
     "promise": {
       "version": "7.3.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
       }
@@ -7440,7 +7440,7 @@
     },
     "promise-retry": {
       "version": "1.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/promise-retry/-/promise-retry-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
       "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "requires": {
         "err-code": "^1.0.0",
@@ -7449,15 +7449,15 @@
       "dependencies": {
         "retry": {
           "version": "0.10.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/retry/-/retry-0.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
           "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
         }
       }
     },
     "proxy-agent": {
       "version": "3.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/proxy-agent/-/proxy-agent-3.1.1.tgz",
-      "integrity": "sha1-fgTga/Nq+mJKFUC+JHtHyXC9MBQ=",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-3.1.1.tgz",
+      "integrity": "sha512-WudaR0eTsDx33O3EJE16PjBRZWcX8GqCEeERw1W3hZJgH/F2a46g7jty6UGty6NeJ4CKQy8ds2CJPMiyeqaTvw==",
       "requires": {
         "agent-base": "^4.2.0",
         "debug": "4",
@@ -7471,36 +7471,36 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "lru-cache": {
           "version": "5.1.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "requires": {
             "yallist": "^3.0.2"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "yallist": {
           "version": "3.1.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0="
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
     "proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha1-4QLxbKNVQkhldV0sno6k8k1Yw+I="
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -7509,13 +7509,13 @@
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ="
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pug": {
       "version": "2.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug/-/pug-2.0.4.tgz",
-      "integrity": "sha1-7naC7ApgSUs41IqI8F87CskxN30=",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
+      "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
       "requires": {
         "pug-code-gen": "^2.0.2",
         "pug-filters": "^3.1.1",
@@ -7529,8 +7529,8 @@
     },
     "pug-attrs": {
       "version": "2.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-attrs/-/pug-attrs-2.0.4.tgz",
-      "integrity": "sha1-svRMQ55OtK1dTvJcrCDRitKMwzY=",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
+      "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
       "requires": {
         "constantinople": "^3.0.1",
         "js-stringify": "^1.0.1",
@@ -7539,8 +7539,8 @@
     },
     "pug-code-gen": {
       "version": "2.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-code-gen/-/pug-code-gen-2.0.2.tgz",
-      "integrity": "sha1-rQlnFirqB33PeHg42U7RSssCF8I=",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.2.tgz",
+      "integrity": "sha512-kROFWv/AHx/9CRgoGJeRSm+4mLWchbgpRzTEn8XCiwwOy6Vh0gAClS8Vh5TEJ9DBjaP8wCjS3J6HKsEsYdvaCw==",
       "requires": {
         "constantinople": "^3.1.2",
         "doctypes": "^1.1.0",
@@ -7554,13 +7554,13 @@
     },
     "pug-error": {
       "version": "1.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-error/-/pug-error-1.3.3.tgz",
-      "integrity": "sha1-80L7AIdS1YA0wYXeA2At2f/hX6Y="
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
+      "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ=="
     },
     "pug-filters": {
       "version": "3.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-filters/-/pug-filters-3.1.1.tgz",
-      "integrity": "sha1-qyzILbnuzPV4vaiRMOJSoNsCaqc=",
+      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
+      "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
       "requires": {
         "clean-css": "^4.1.11",
         "constantinople": "^3.0.1",
@@ -7573,8 +7573,8 @@
     },
     "pug-lexer": {
       "version": "4.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-lexer/-/pug-lexer-4.1.0.tgz",
-      "integrity": "sha1-UxzeSMfAsfy7wrhUhchmXjFInP0=",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
+      "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
       "requires": {
         "character-parser": "^2.1.1",
         "is-expression": "^3.0.0",
@@ -7583,8 +7583,8 @@
     },
     "pug-linker": {
       "version": "3.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-linker/-/pug-linker-3.0.6.tgz",
-      "integrity": "sha1-9b8hiw79Zc5mcPevxRZY0Pgpifs=",
+      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
+      "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
       "requires": {
         "pug-error": "^1.3.3",
         "pug-walk": "^1.1.8"
@@ -7592,8 +7592,8 @@
     },
     "pug-load": {
       "version": "2.0.12",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-load/-/pug-load-2.0.12.tgz",
-      "integrity": "sha1-04yF64X24vcE3qFNzKlBRNNdPns=",
+      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
+      "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
       "requires": {
         "object-assign": "^4.1.0",
         "pug-walk": "^1.1.8"
@@ -7601,8 +7601,8 @@
     },
     "pug-parser": {
       "version": "5.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-parser/-/pug-parser-5.0.1.tgz",
-      "integrity": "sha1-A+etpItoQL04Ivhn19kPhC0P/ck=",
+      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
+      "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
       "requires": {
         "pug-error": "^1.3.3",
         "token-stream": "0.0.1"
@@ -7610,21 +7610,21 @@
     },
     "pug-runtime": {
       "version": "2.0.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-runtime/-/pug-runtime-2.0.5.tgz",
-      "integrity": "sha1-baeXbDa/IvaOczw1kkDYrnoylTo="
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
+      "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw=="
     },
     "pug-strip-comments": {
       "version": "1.0.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
-      "integrity": "sha1-zBtt4fbo9ZMc8C7GbN/9P1Dq+Kg=",
+      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
+      "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
       "requires": {
         "pug-error": "^1.3.3"
       }
     },
     "pug-walk": {
       "version": "1.1.8",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/pug-walk/-/pug-walk-1.1.8.tgz",
-      "integrity": "sha1-tAj2fyeRL4wh2i9FtyMMS9Kl6no="
+      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
+      "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -7633,8 +7633,8 @@
     },
     "qs": {
       "version": "6.9.4",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha1-kJCykNH5FyjTwi5UhDykSupatoc="
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "randomatic": {
       "version": "3.1.1",
@@ -7666,8 +7666,8 @@
     },
     "raw-body": {
       "version": "2.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/raw-body/-/raw-body-2.4.1.tgz",
-      "integrity": "sha1-MKyC+Yu1rowVLmcUnayNVRU7Fow=",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
       "requires": {
         "bytes": "3.1.0",
         "http-errors": "1.7.3",
@@ -7677,8 +7677,8 @@
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -8127,8 +8127,8 @@
     },
     "request": {
       "version": "2.88.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/request/-/request-2.88.2.tgz",
-      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -8154,8 +8154,8 @@
       "dependencies": {
         "form-data": {
           "version": "2.3.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -8164,13 +8164,13 @@
         },
         "qs": {
           "version": "6.5.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "uuid": {
           "version": "3.4.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -8213,8 +8213,8 @@
     },
     "rest-facade": {
       "version": "1.12.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/rest-facade/-/rest-facade-1.12.0.tgz",
-      "integrity": "sha1-5qJZWLNLqyMjr1qVPAE1rCaE03E=",
+      "resolved": "https://registry.npmjs.org/rest-facade/-/rest-facade-1.12.0.tgz",
+      "integrity": "sha512-LsrzWP+aAy8LWwAi1ZshecO7nOWWZB9bB4gJTwXLl5DS40D5vmmdupKvqEcz8m0GUybLI3uJX8bofJtSrs5Acw==",
       "requires": {
         "change-case": "^2.3.0",
         "deepmerge": "^3.2.0",
@@ -8225,16 +8225,16 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "form-data": {
           "version": "2.5.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -8243,13 +8243,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "superagent": {
           "version": "3.8.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent/-/superagent-3.8.3.tgz",
-          "integrity": "sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+          "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
           "requires": {
             "component-emitter": "^1.2.0",
             "cookiejar": "^2.1.0",
@@ -8284,12 +8284,12 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
         "align-text": "^0.1.1"
@@ -8354,7 +8354,7 @@
     },
     "sentence-case": {
       "version": "1.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/sentence-case/-/sentence-case-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
       "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
       "requires": {
         "lower-case": "^1.1.1"
@@ -8387,8 +8387,8 @@
     },
     "setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -8428,12 +8428,12 @@
     },
     "smart-buffer": {
       "version": "4.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha1-kWBcJdkWUvRmHqacz0XxszHKIbo="
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
     },
     "snake-case": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/snake-case/-/snake-case-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
       "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
       "requires": {
         "sentence-case": "^1.1.2"
@@ -8560,8 +8560,8 @@
     },
     "socks": {
       "version": "2.3.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/socks/-/socks-2.3.3.tgz",
-      "integrity": "sha1-ARKfCl1TTSuJdxLtis6rfuZdeOM=",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
       "requires": {
         "ip": "1.1.5",
         "smart-buffer": "^4.1.0"
@@ -8569,8 +8569,8 @@
     },
     "socks-proxy-agent": {
       "version": "4.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
-      "integrity": "sha1-PImR8xRbJ5nnDhG9X7yLGWMRY4Y=",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-4.0.2.tgz",
+      "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
       "requires": {
         "agent-base": "~4.2.1",
         "socks": "~2.3.2"
@@ -8578,8 +8578,8 @@
       "dependencies": {
         "agent-base": {
           "version": "4.2.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/agent-base/-/agent-base-4.2.1.tgz",
-          "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
           "requires": {
             "es6-promisify": "^5.0.0"
           }
@@ -8662,8 +8662,8 @@
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -8706,7 +8706,7 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-width": {
@@ -8750,8 +8750,8 @@
     },
     "superagent": {
       "version": "3.8.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent/-/superagent-3.8.1.tgz",
-      "integrity": "sha1-JXH9kh8/zbpDrGjDs1yRlRUycB8=",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.1.tgz",
+      "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
       "requires": {
         "component-emitter": "^1.2.0",
         "cookiejar": "^2.1.0",
@@ -8767,16 +8767,16 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "form-data": {
           "version": "2.5.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -8785,15 +8785,15 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "superagent-proxy": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent-proxy/-/superagent-proxy-2.0.0.tgz",
-      "integrity": "sha1-n1dRXNZg4unOVcDmvXD5LrB8PuA=",
+      "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-2.0.0.tgz",
+      "integrity": "sha512-TktJma5jPdiH1BNN+reF/RMW3b8aBTCV7KlLFV0uYcREgNf3pvo7Rdt564OcFHwkGb3mYEhHuWPBhSbOwiNaYw==",
       "requires": {
         "debug": "^3.1.0",
         "proxy-agent": "3"
@@ -8801,16 +8801,16 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -8825,7 +8825,7 @@
     },
     "swap-case": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/swap-case/-/swap-case-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "requires": {
         "lower-case": "^1.1.1",
@@ -8911,12 +8911,12 @@
     },
     "thunkify": {
       "version": "2.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/thunkify/-/thunkify-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/thunkify/-/thunkify-2.1.2.tgz",
       "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0="
     },
     "title-case": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/title-case/-/title-case-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
       "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
       "requires": {
         "sentence-case": "^1.1.1",
@@ -8985,18 +8985,18 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "token-stream": {
       "version": "0.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/token-stream/-/token-stream-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
       "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -9010,7 +9010,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -9018,7 +9018,7 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
@@ -9043,7 +9043,7 @@
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
         "source-map": "~0.5.1",
@@ -9053,14 +9053,14 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
@@ -9079,7 +9079,7 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
@@ -9128,12 +9128,12 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
     "upper-case-first": {
       "version": "1.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "requires": {
         "upper-case": "^1.1.1"
@@ -9193,7 +9193,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
         "assert-plus": "^1.0.0",
@@ -9203,18 +9203,18 @@
     },
     "very-fast-args": {
       "version": "1.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/very-fast-args/-/very-fast-args-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/very-fast-args/-/very-fast-args-1.1.0.tgz",
       "integrity": "sha1-4W0dH6+KbllqJGQh/ZCneWPQs5Y="
     },
     "void-elements": {
       "version": "2.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/void-elements/-/void-elements-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
     },
     "webtask-tools": {
       "version": "3.4.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/webtask-tools/-/webtask-tools-3.4.1.tgz",
-      "integrity": "sha1-IkPvDlgymSpgjuaRJQljj0ZQTIQ=",
+      "resolved": "https://registry.npmjs.org/webtask-tools/-/webtask-tools-3.4.1.tgz",
+      "integrity": "sha512-NqjvLZVA3AUsRLWBIEcNH7jEoBZERjb1w3JANg/KjxUkEcmS+c8bcBPAGIy+awhgVax2E52qs6bZhiPg842aCw==",
       "requires": {
         "boom": "^7.2.0",
         "jsonwebtoken": "^5.7.0",
@@ -9225,23 +9225,23 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           },
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
             }
           }
         },
         "form-data": {
           "version": "2.5.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -9250,7 +9250,7 @@
         },
         "jsonwebtoken": {
           "version": "5.7.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz",
           "integrity": "sha1-HJD5qGzlt0j1+XnBK3BAK0r83bQ=",
           "requires": {
             "jws": "^3.0.0",
@@ -9260,13 +9260,13 @@
         },
         "ms": {
           "version": "0.7.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ms/-/ms-0.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
           "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
         },
         "superagent": {
           "version": "3.8.3",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/superagent/-/superagent-3.8.3.tgz",
-          "integrity": "sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+          "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
           "requires": {
             "component-emitter": "^1.2.0",
             "cookiejar": "^2.1.0",
@@ -9293,7 +9293,7 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
     },
     "winston": {
@@ -9318,7 +9318,7 @@
     },
     "with": {
       "version": "5.1.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/with/-/with-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
       "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
       "requires": {
         "acorn": "^3.1.0",
@@ -9346,13 +9346,13 @@
     },
     "xregexp": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/xregexp/-/xregexp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
       "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "2.1.2",
@@ -9361,7 +9361,7 @@
     },
     "yargs": {
       "version": "3.10.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yargs/-/yargs-3.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
         "camelcase": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "ajv": "^6.5.2",
-    "auth0-extension-tools": "^1.4.4",
+    "auth0-extension-tools": "^1.5.0",
     "babel-preset-env": "^1.7.0",
     "dot-prop": "^4.2.0",
     "promise-pool-executor": "^1.1.1",

--- a/src/auth0/handlers/index.js
+++ b/src/auth0/handlers/index.js
@@ -16,6 +16,7 @@ import * as guardianFactorTemplates from './guardianFactorTemplates';
 import * as roles from './roles';
 import * as branding from './branding';
 import * as prompts from './prompts';
+import * as migrations from './migrations';
 
 export {
   rules,
@@ -35,5 +36,6 @@ export {
   guardianFactorTemplates,
   roles,
   branding,
-  prompts
+  prompts,
+  migrations
 };

--- a/src/auth0/handlers/migrations.js
+++ b/src/auth0/handlers/migrations.js
@@ -1,0 +1,33 @@
+import DefaultHandler, { order } from './default';
+
+export const schema = {
+  type: 'object',
+  additionalProperties: { type: 'boolean' }
+};
+
+
+export default class MigrationsHandler extends DefaultHandler {
+  constructor(options) {
+    super({
+      ...options,
+      type: 'migrations'
+    });
+  }
+
+  async getType() {
+    const migrations = await this.client.migrations.getMigrations();
+    return migrations.flags;
+  }
+
+  // Run at the end since switching a flag will depend on other applying other changes
+  @order('150')
+  async processChanges(assets) {
+    const { migrations } = assets;
+
+    if (migrations && Object.keys(migrations).length > 0) {
+      await this.client.migrations.updateMigrations({ flags: migrations });
+      this.updated += 1;
+      this.didUpdate(migrations);
+    }
+  }
+}

--- a/src/auth0/handlers/migrations.js
+++ b/src/auth0/handlers/migrations.js
@@ -24,25 +24,34 @@ export default class MigrationsHandler extends DefaultHandler {
   @order('150')
   async processChanges(assets) {
     const { migrations } = assets;
-    const ignoreUnavailableMigrations = this.config('AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS');
 
     if (migrations && Object.keys(migrations).length > 0) {
-      const existingMigrations = await this.client.migrations.getMigrations();
-      const supportedMigrations = Object.keys(existingMigrations.flags);
-      const unavailableMigrations = Object.keys(migrations).filter(flag => !supportedMigrations.includes(flag));
-      const unavailableDisabledMigrations = unavailableMigrations.filter(flag => migrations[flag] === false);
+      const flags = await this.removeUnavailableMigrations(migrations);
 
-      if (ignoreUnavailableMigrations && unavailableMigrations.length > 0) {
-        log.info(`The following migrations are not available '${unavailableDisabledMigrations.join(',')}'. The migrations will be ignored because you have AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS=true in your configuration.`);
-        unavailableMigrations.forEach(flag => delete migrations[flag]);
-      } else if (unavailableDisabledMigrations.length > 0) {
-        log.warn(`The following disabled migrations are not available '${unavailableDisabledMigrations.join(',')}'. The migrations will be ignored, remove the migrations to avoid future warnings.`);
-        unavailableDisabledMigrations.forEach(flag => delete migrations[flag]);
-      }
-
-      await this.client.migrations.updateMigrations({ flags: migrations });
+      await this.client.migrations.updateMigrations({ flags });
       this.updated += 1;
       this.didUpdate(migrations);
     }
+  }
+
+  logUnavailableMigrations(ignoreUnavailableMigrations, unavailableMigrations) {
+    if (ignoreUnavailableMigrations) {
+      log.info(`The following migrations are not available '${unavailableMigrations.join(',')}'. The migrations will be ignored because you have AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS=true in your configuration.`);
+    } else {
+      log.warn(`The following disabled migrations are not available '${unavailableMigrations.join(',')}'. The migrations will be ignored, remove the migrations to avoid future warnings.`);
+    }
+  }
+
+  async removeUnavailableMigrations(migrations) {
+    const flags = Object.assign({}, migrations);
+    const ignoreUnavailableMigrations = !!this.config('AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS');
+    const existingMigrations = await this.getType();
+    const unavailableMigrations = Object.keys(flags).filter(flag => !(flag in existingMigrations) && (ignoreUnavailableMigrations || flags[flag] === false));
+
+    if (unavailableMigrations.length > 0) {
+      this.logUnavailableMigrations(ignoreUnavailableMigrations, unavailableMigrations);
+      unavailableMigrations.forEach(flag => delete flags[flag]);
+    }
+    return flags;
   }
 }

--- a/src/auth0/handlers/migrations.js
+++ b/src/auth0/handlers/migrations.js
@@ -1,4 +1,5 @@
 import DefaultHandler, { order } from './default';
+import log from '../../logger';
 
 export const schema = {
   type: 'object',
@@ -23,8 +24,22 @@ export default class MigrationsHandler extends DefaultHandler {
   @order('150')
   async processChanges(assets) {
     const { migrations } = assets;
+    const ignoreUnavailableMigrations = this.config('AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS');
 
     if (migrations && Object.keys(migrations).length > 0) {
+      const existingMigrations = await this.client.migrations.getMigrations();
+      const supportedMigrations = Object.keys(existingMigrations.flags);
+      const unavailableMigrations = Object.keys(migrations).filter(flag => !supportedMigrations.includes(flag));
+      const unavailableDisabledMigrations = unavailableMigrations.filter(flag => migrations[flag] === false);
+
+      if (ignoreUnavailableMigrations && unavailableMigrations.length > 0) {
+        log.info(`The following migrations are not available '${unavailableDisabledMigrations.join(',')}'. The migrations will be ignored because you have AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS=true in your configuration.`);
+        unavailableMigrations.forEach(flag => delete migrations[flag]);
+      } else if (unavailableDisabledMigrations.length > 0) {
+        log.warn(`The following disabled migrations are not available '${unavailableDisabledMigrations.join(',')}'. The migrations will be ignored, remove the migrations to avoid future warnings.`);
+        unavailableDisabledMigrations.forEach(flag => delete migrations[flag]);
+      }
+
       await this.client.migrations.updateMigrations({ flags: migrations });
       this.updated += 1;
       this.didUpdate(migrations);

--- a/src/auth0/handlers/migrations.js
+++ b/src/auth0/handlers/migrations.js
@@ -28,9 +28,11 @@ export default class MigrationsHandler extends DefaultHandler {
     if (migrations && Object.keys(migrations).length > 0) {
       const flags = await this.removeUnavailableMigrations(migrations);
 
-      await this.client.migrations.updateMigrations({ flags });
-      this.updated += 1;
-      this.didUpdate(migrations);
+      if (Object.keys(flags).length > 0) {
+        await this.client.migrations.updateMigrations({ flags });
+        this.updated += 1;
+        this.didUpdate(flags);
+      }
     }
   }
 

--- a/src/auth0/handlers/migrations.js
+++ b/src/auth0/handlers/migrations.js
@@ -36,11 +36,11 @@ export default class MigrationsHandler extends DefaultHandler {
     }
   }
 
-  logUnavailableMigrations(ignoreUnavailableMigrations, unavailableMigrations) {
+  logUnavailableMigrations(ignoreUnavailableMigrations, ignoredMigrations) {
     if (ignoreUnavailableMigrations) {
-      log.info(`The following migrations are not available '${unavailableMigrations.join(',')}'. The migrations will be ignored because you have AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS=true in your configuration.`);
+      log.info(`The following migrations are not available '${ignoredMigrations.join(',')}'. The migrations will be ignored because you have AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS=true in your configuration.`);
     } else {
-      log.warn(`The following disabled migrations are not available '${unavailableMigrations.join(',')}'. The migrations will be ignored, remove the migrations to avoid future warnings.`);
+      log.warn(`The following disabled migrations are not available '${ignoredMigrations.join(',')}'. The migrations will be ignored, remove the migrations to avoid future warnings.`);
     }
   }
 
@@ -48,11 +48,12 @@ export default class MigrationsHandler extends DefaultHandler {
     const flags = Object.assign({}, migrations);
     const ignoreUnavailableMigrations = !!this.config('AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS');
     const existingMigrations = await this.getType();
-    const unavailableMigrations = Object.keys(flags).filter(flag => !(flag in existingMigrations) && (ignoreUnavailableMigrations || flags[flag] === false));
+    const unavailableMigrations = Object.keys(flags).filter(flag => !(flag in existingMigrations));
+    const ignoredMigrations = unavailableMigrations.filter(flag => ignoreUnavailableMigrations || flags[flag] === false);
 
-    if (unavailableMigrations.length > 0) {
-      this.logUnavailableMigrations(ignoreUnavailableMigrations, unavailableMigrations);
-      unavailableMigrations.forEach(flag => delete flags[flag]);
+    if (ignoredMigrations.length > 0) {
+      this.logUnavailableMigrations(ignoreUnavailableMigrations, ignoredMigrations);
+      ignoredMigrations.forEach(flag => delete flags[flag]);
     }
     return flags;
   }

--- a/src/auth0/handlers/pages.js
+++ b/src/auth0/handlers/pages.js
@@ -19,7 +19,7 @@ export const schema = {
     properties: {
       name: { type: 'string', enum: supportedPages },
       html: { type: 'string', default: '' },
-      url: { type: 'string', default: '' },
+      url: { type: 'string' },
       show_log_link: { type: 'boolean' },
       enabled: { type: 'boolean' }
     },

--- a/tests/auth0/handlers/migrations.tests.js
+++ b/tests/auth0/handlers/migrations.tests.js
@@ -2,44 +2,96 @@ const { expect } = require('chai');
 const migrations = require('../../../src/auth0/handlers/migrations');
 
 describe('#migrations handler', () => {
-  describe('#migrations process', () => {
-    it('should get migration flags', async () => {
-      const auth0 = {
-        migrations: {
-          getMigrations: () => ({
-            flags: {
-              migration_flag: true
-            }
-          })
+  const mockClient = flags => ({
+    migrations: {
+      getMigrations: () => ({
+        flags: {
+          migration_flag: true
         }
-      };
+      }),
+      updateMigrations: (data) => {
+        expect(data).to.be.an('object');
+        expect(data).to.have.deep.property('flags', { migration_flag: false, ...flags });
+        return Promise.resolve(data);
+      }
+    }
+  });
 
-      const handler = new migrations.default({ client: auth0 });
+  describe('#getType()', () => {
+    it('should get migration flags', async () => {
+      const client = mockClient();
+
+      const handler = new migrations.default({ client });
       const data = await handler.getType();
       expect(data).to.deep.equal({
         migration_flag: true
       });
     });
+  });
 
-    it('should update migration flags', async () => {
-      const auth0 = {
-        migrations: {
-          updateMigrations: (data) => {
-            expect(data).to.be.an('object');
-            expect(data).to.have.deep.property('flags', { new_migration_flag: true });
-            return Promise.resolve(data);
-          }
-        }
-      };
+  describe('#migrations process', () => {
+    it('should update available migration flags', async () => {
+      const client = mockClient();
+      const config = () => false;
 
-      const handler = new migrations.default({ client: auth0 });
+      const handler = new migrations.default({ client, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [ {
         migrations: {
-          new_migration_flag: true
+          migration_flag: false
         }
       } ]);
+    });
+
+    describe('when AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS=false (default)', () => {
+      it('should ignore unavailable disabled migration flags', async () => {
+        const client = mockClient();
+        const config = () => false;
+
+        const handler = new migrations.default({ client, config });
+        const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+        await stageFn.apply(handler, [ {
+          migrations: {
+            migration_flag: false,
+            disabled_flag: false
+          }
+        } ]);
+      });
+
+      it('should not ignore unavailable enabled migration flags', async () => {
+        const client = mockClient({ disabled_flag: true });
+        const config = () => false;
+
+        const handler = new migrations.default({ client, config });
+        const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+        await stageFn.apply(handler, [ {
+          migrations: {
+            migration_flag: false,
+            disabled_flag: true
+          }
+        } ]);
+      });
+    });
+
+    describe('when AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS=true', () => {
+      it('should ignore all unavailable migration flags', async () => {
+        const client = mockClient();
+        const config = name => name === 'AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS';
+
+        const handler = new migrations.default({ client, config });
+        const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+        await stageFn.apply(handler, [ {
+          migrations: {
+            migration_flag: false,
+            disabled_flag: true,
+            another_disabled_flag: false
+          }
+        } ]);
+      });
     });
   });
 });

--- a/tests/auth0/handlers/migrations.tests.js
+++ b/tests/auth0/handlers/migrations.tests.js
@@ -1,5 +1,6 @@
+import migrations from '../../../src/auth0/handlers/migrations';
+
 const { expect } = require('chai');
-const migrations = require('../../../src/auth0/handlers/migrations');
 
 describe('#migrations handler', () => {
   const mockClient = flags => ({
@@ -21,7 +22,7 @@ describe('#migrations handler', () => {
     it('should get migration flags', async () => {
       const client = mockClient();
 
-      const handler = new migrations.default({ client });
+      const handler = new migrations({ client });
       const data = await handler.getType();
       expect(data).to.deep.equal({
         migration_flag: true
@@ -34,7 +35,7 @@ describe('#migrations handler', () => {
       const client = mockClient();
       const config = () => false;
 
-      const handler = new migrations.default({ client, config });
+      const handler = new migrations({ client, config });
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [ {
@@ -49,7 +50,7 @@ describe('#migrations handler', () => {
         const client = mockClient();
         const config = () => false;
 
-        const handler = new migrations.default({ client, config });
+        const handler = new migrations({ client, config });
         const stageFn = Object.getPrototypeOf(handler).processChanges;
 
         await stageFn.apply(handler, [ {
@@ -65,7 +66,7 @@ describe('#migrations handler', () => {
         const config = () => false;
         client.migrations.updateMigrations = () => { throw new Error('tried to update migrations'); };
 
-        const handler = new migrations.default({ client, config });
+        const handler = new migrations({ client, config });
         const stageFn = Object.getPrototypeOf(handler).processChanges;
 
         await stageFn.apply(handler, [ {
@@ -79,7 +80,7 @@ describe('#migrations handler', () => {
         const client = mockClient({ disabled_flag: true });
         const config = () => false;
 
-        const handler = new migrations.default({ client, config });
+        const handler = new migrations({ client, config });
         const stageFn = Object.getPrototypeOf(handler).processChanges;
 
         await stageFn.apply(handler, [ {
@@ -96,7 +97,7 @@ describe('#migrations handler', () => {
         const client = mockClient();
         const config = name => name === 'AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS';
 
-        const handler = new migrations.default({ client, config });
+        const handler = new migrations({ client, config });
         const stageFn = Object.getPrototypeOf(handler).processChanges;
 
         await stageFn.apply(handler, [ {

--- a/tests/auth0/handlers/migrations.tests.js
+++ b/tests/auth0/handlers/migrations.tests.js
@@ -1,0 +1,45 @@
+const { expect } = require('chai');
+const migrations = require('../../../src/auth0/handlers/migrations');
+
+describe('#migrations handler', () => {
+  describe('#migrations process', () => {
+    it('should get migration flags', async () => {
+      const auth0 = {
+        migrations: {
+          getMigrations: () => ({
+            flags: {
+              migration_flag: true
+            }
+          })
+        }
+      };
+
+      const handler = new migrations.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({
+        migration_flag: true
+      });
+    });
+
+    it('should update migration flags', async () => {
+      const auth0 = {
+        migrations: {
+          updateMigrations: (data) => {
+            expect(data).to.be.an('object');
+            expect(data).to.have.deep.property('flags', { new_migration_flag: true });
+            return Promise.resolve(data);
+          }
+        }
+      };
+
+      const handler = new migrations.default({ client: auth0 });
+      const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+      await stageFn.apply(handler, [ {
+        migrations: {
+          new_migration_flag: true
+        }
+      } ]);
+    });
+  });
+});

--- a/tests/auth0/handlers/migrations.tests.js
+++ b/tests/auth0/handlers/migrations.tests.js
@@ -60,6 +60,21 @@ describe('#migrations handler', () => {
         } ]);
       });
 
+      it('should not try to update if all flags are ignored', async () => {
+        const client = mockClient();
+        const config = () => false;
+        client.migrations.updateMigrations = () => { throw new Error('tried to update migrations'); };
+
+        const handler = new migrations.default({ client, config });
+        const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+        await stageFn.apply(handler, [ {
+          migrations: {
+            disabled_flag: false
+          }
+        } ]);
+      });
+
       it('should not ignore unavailable enabled migration flags', async () => {
         const client = mockClient({ disabled_flag: true });
         const config = () => false;

--- a/tests/auth0/validator.tests.js
+++ b/tests/auth0/validator.tests.js
@@ -611,4 +611,32 @@ describe('#schema validation tests', () => {
       checkPassed({ tenant: data }, done);
     });
   });
+
+  describe('#migrations validate', () => {
+    it('should fail validation if migrations is not an object', (done) => {
+      const data = '';
+
+      const auth0 = new Auth0({}, { migrations: data }, {});
+
+      auth0.validate().then(failedCb(done), passedCb(done, 'should be object'));
+    });
+
+    it('should fail validation if migrations properties are not boolean', (done) => {
+      const data = {
+        migration_flag: 'string'
+      };
+
+      const auth0 = new Auth0({}, { migrations: data }, {});
+
+      auth0.validate().then(failedCb(done), passedCb(done, 'should be boolean'));
+    });
+
+    it('should pass validation', (done) => {
+      const data = {
+        migration_flag: true
+      };
+
+      checkPassed({ migrations: data }, done);
+    });
+  });
 });


### PR DESCRIPTION
## ✏️ Changes
 Adds support for the new migrations endpoint. This is expected to be passed in the `migrations` property as a set of properties of type `boolean`.

When updating migrations the following checks are performed:

- The migration flags being set are compared with the migration flags available for the tenant at the moment of processing the import ([code](https://github.com/auth0-extensions/auth0-source-control-extension-tools/pull/97/files#diff-866ff42ac5a4faf805db4eb15fc0de0fR50)).
- If there are any migration flags that are not available. The behavior will depend on the value set for the flag:
  - If the flag value is set to `false`, meaning that the migration is being disabled, we will log a *warning* and ignore the flag.
  - if the flag value is set to `true`, meaning the migration is still enabled, it will be sent to the server.

The goal of the logic is that the flag van be disabled via the deployment tools and avoid causing errors when the migration period ends.

Additionally a configuration parameter `AUTH0_IGNORE_UNAVAILABLE_MIGRATIONS` allows to ignore all migrations flags not available regardless of its value. In this case we will log an *info* message with the names of the flags ignored.
  
## 🔗 References
https://github.com/auth0/node-auth0/pull/503

  
## 🎯 Testing
  
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
    
🚫 This can be deployed any time
  
⚠️  This has be completed with the version bumps in `node-auth0`