### PR TITLE
fix: error for extra `url` when importing change_password

### DIFF
--- a/src/auth0/handlers/pages.js
+++ b/src/auth0/handlers/pages.js
@@ -19,7 +19,7 @@ export const schema = {
     properties: {
       name: { type: 'string', enum: supportedPages },
       html: { type: 'string', default: '' },
-      url: { type: 'string', default: '' },
+      url: { type: 'string' },
       show_log_link: { type: 'boolean' },
       enabled: { type: 'boolean' }
     },


### PR DESCRIPTION
## ✏️ Changes
  
Fixes: https://github.com/auth0/auth0-deploy-cli/issues/255

To reproduce:
- Install deploy-cli to latest version. Make sure that it installs the auth0-source-control-extension-tools to version 4.1.0 (released on July 2nd).
- Ensure your tenant has a custom `change_password` page.
- Export tenant settings
- Try to re-import tenant settings.

Error:
```
2020-07-06T18:08:20.319Z - error: Problem running command import during stage processChanges when processing type pages
2020-07-06T18:08:20.320Z - error: Payload validation error: 'Additional properties not allowed: url' on property change_password (Change Password page customization).
```

Explanation: the `default` value set for the `url` attribute in the JSON schema causes the validation logic to always add a `url` attribute set to `""` on all pages, even on the `change_password` page that does not support this attribute (only the `error_page` supports it).


## 📷 Screenshots
 
⛔ 
  
## 🔗 References
  
Error report: https://github.com/auth0/auth0-deploy-cli/issues/255
  
## 🎯 Testing
  
🚫 This change has been tested in a Webtask

✅ This change has been tested using a local installation of Deploy CLI
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
 
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
