### PR TITLE
[MFA-351] fix(guardian): support for older installations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/guardianPhoneFactorSelectedProvider.js
+++ b/src/auth0/handlers/guardianPhoneFactorSelectedProvider.js
@@ -9,10 +9,24 @@ export const schema = {
       enum: constants.GUARDIAN_PHONE_PROVIDERS
     }
   },
-  required: [ 'provider' ],
   additionalProperties: false
 };
 
+const isFeatureUnavailableError = (err) => {
+  if (err.statusCode === 404) {
+    // Older Management API version where the endpoint is not available.
+    return true;
+  }
+  if (err.statusCode === 403
+    && err.originalError
+    && err.originalError.response
+    && err.originalError.response.body
+    && err.originalError.response.body.errorCode === 'hooks_not_allowed') {
+    // Recent Management API version, but with feature explicitly disabled.
+    return true;
+  }
+  return false;
+};
 
 export default class GuardianPhoneSelectedProviderHandler extends DefaultHandler {
   constructor(options) {
@@ -25,11 +39,21 @@ export default class GuardianPhoneSelectedProviderHandler extends DefaultHandler
   async getType() {
     // in case client version does not support the operation
     if (!this.client.guardian || typeof this.client.guardian.getPhoneFactorSelectedProvider !== 'function') {
-      return null;
+      return {};
     }
 
     if (this.existing) return this.existing;
-    this.existing = await this.client.guardian.getPhoneFactorSelectedProvider();
+
+    try {
+      this.existing = await this.client.guardian.getPhoneFactorSelectedProvider();
+    } catch (e) {
+      if (isFeatureUnavailableError(e)) {
+        // Gracefully skip processing this configuration value.
+        return {};
+      }
+      throw e;
+    }
+
     return this.existing;
   }
 
@@ -38,7 +62,7 @@ export default class GuardianPhoneSelectedProviderHandler extends DefaultHandler
     const { guardianPhoneFactorSelectedProvider } = assets;
 
     // Do nothing if not set
-    if (!guardianPhoneFactorSelectedProvider) return;
+    if (!guardianPhoneFactorSelectedProvider || !guardianPhoneFactorSelectedProvider.provider) return;
 
     const params = {};
     const data = guardianPhoneFactorSelectedProvider;

--- a/src/auth0/handlers/guardianPolicies.js
+++ b/src/auth0/handlers/guardianPolicies.js
@@ -2,15 +2,18 @@ import DefaultHandler from './default';
 import constants from '../../constants';
 
 export const schema = {
-  type: 'array',
-  items: {
-    type: 'string',
-    enum: constants.GUARDIAN_POLICIES
+  type: 'object',
+  properties: {
+    policies: {
+      type: 'array',
+      items: {
+        type: 'string',
+        enum: constants.GUARDIAN_POLICIES
+      }
+    }
   },
-  minLength: 0,
-  maxLength: 1
+  additionalProperties: false
 };
-
 
 export default class GuardianPoliciesHandler extends DefaultHandler {
   constructor(options) {
@@ -23,11 +26,12 @@ export default class GuardianPoliciesHandler extends DefaultHandler {
   async getType() {
     // in case client version does not support the operation
     if (!this.client.guardian || typeof this.client.guardian.getPolicies !== 'function') {
-      return null;
+      return {};
     }
 
     if (this.existing) return this.existing;
-    this.existing = await this.client.guardian.getPolicies();
+    const policies = await this.client.guardian.getPolicies();
+    this.existing = { policies };
     return this.existing;
   }
 
@@ -36,10 +40,10 @@ export default class GuardianPoliciesHandler extends DefaultHandler {
     const { guardianPolicies } = assets;
 
     // Do nothing if not set
-    if (!guardianPolicies) return;
+    if (!guardianPolicies || !guardianPolicies.policies) return;
 
     const params = {};
-    const data = guardianPolicies;
+    const data = guardianPolicies.policies;
     await this.client.guardian.updatePolicies(params, data);
     this.updated += 1;
     this.didUpdate(guardianPolicies);

--- a/tests/auth0/handlers/guardianPhoneFactorMessageTypes.tests.js
+++ b/tests/auth0/handlers/guardianPhoneFactorMessageTypes.tests.js
@@ -12,7 +12,68 @@ describe('#guardianPhoneFactorMessageTypes handler', () => {
 
       const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
       const data = await handler.getType();
-      expect(data).to.deep.equal(null);
+      expect(data).to.deep.equal({});
+    });
+
+    it('should support when endpoint does not exist (older installations)', async () => {
+      const auth0 = {
+        guardian: {
+          getPhoneFactorMessageTypes: () => {
+            const err = new Error('Not Found');
+            err.name = 'Not Found';
+            err.statusCode = 404;
+            err.requestInfo = {
+              method: 'get',
+              url: 'https://example.auth0.com/api/v2/guardian/factors/phone/message-types'
+            };
+            err.originalError = new Error('Not Found');
+            err.originalError.status = 404;
+            err.originalError.response = {
+              body: {
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'Not Found'
+              }
+            };
+            return Promise.reject(err);
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({});
+    });
+
+    it('should support when endpoint is disabled for tenant', async () => {
+      const auth0 = {
+        guardian: {
+          getPhoneFactorMessageTypes: () => {
+            const err = new Error('This endpoint is disabled for your tenant.');
+            err.name = 'Forbidden';
+            err.statusCode = 403;
+            err.requestInfo = {
+              method: 'get',
+              url: 'https://example.auth0.com/api/v2/guardian/factors/phone/message-types'
+            };
+            err.originalError = new Error('Forbidden');
+            err.originalError.status = 403;
+            err.originalError.response = {
+              body: {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'This endpoint is disabled for your tenant.',
+                errorCode: 'voice_mfa_not_allowed'
+              }
+            };
+            return Promise.reject(err);
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({});
     });
 
     it('should get guardian phone factor message types', async () => {
@@ -25,6 +86,25 @@ describe('#guardianPhoneFactorMessageTypes handler', () => {
       const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
       const data = await handler.getType();
       expect(data).to.deep.equal({ message_types: [ 'sms', 'voice' ] });
+    });
+
+    it('should throw an error for all other failed requests', async () => {
+      const auth0 = {
+        guardian: {
+          getPhoneFactorMessageTypes: () => {
+            const error = new Error('Bad request');
+            error.statusCode = 500;
+            throw error;
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorMessageTypes.default({ client: auth0 });
+      try {
+        await handler.getType();
+      } catch (error) {
+        expect(error).to.be.an.instanceOf(Error);
+      }
     });
   });
 
@@ -61,7 +141,7 @@ describe('#guardianPhoneFactorMessageTypes handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [
-        { guardianPhoneFactorMessageTypes: null }
+        { guardianPhoneFactorMessageTypes: {} }
       ]);
     });
   });

--- a/tests/auth0/handlers/guardianPhoneFactorSelectedProvider.tests.js
+++ b/tests/auth0/handlers/guardianPhoneFactorSelectedProvider.tests.js
@@ -12,7 +12,68 @@ describe('#guardianPhoneFactorSelectedProvider handler', () => {
 
       const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
       const data = await handler.getType();
-      expect(data).to.deep.equal(null);
+      expect(data).to.deep.equal({});
+    });
+
+    it('should support when endpoint does not exist (older installations)', async () => {
+      const auth0 = {
+        guardian: {
+          getPhoneFactorSelectedProvider: () => {
+            const err = new Error('Not Found');
+            err.name = 'Not Found';
+            err.statusCode = 404;
+            err.requestInfo = {
+              method: 'get',
+              url: 'https://example.auth0.com/api/v2/guardian/factors/sms/selected-provider'
+            };
+            err.originalError = new Error('Not Found');
+            err.originalError.status = 404;
+            err.originalError.response = {
+              body: {
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'Not Found'
+              }
+            };
+            return Promise.reject(err);
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({});
+    });
+
+    it('should support when endpoint is disabled for tenant', async () => {
+      const auth0 = {
+        guardian: {
+          getPhoneFactorSelectedProvider: () => {
+            const err = new Error('This endpoint is disabled for your tenant.');
+            err.name = 'Forbidden';
+            err.statusCode = 403;
+            err.requestInfo = {
+              method: 'get',
+              url: 'https://example.auth0.com/api/v2/guardian/factors/sms/selected-provider'
+            };
+            err.originalError = new Error('Forbidden');
+            err.originalError.status = 403;
+            err.originalError.response = {
+              body: {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'This endpoint is disabled for your tenant.',
+                errorCode: 'hooks_not_allowed'
+              }
+            };
+            return Promise.reject(err);
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({});
     });
 
     it('should get guardian phone factor selected provider', async () => {
@@ -25,6 +86,25 @@ describe('#guardianPhoneFactorSelectedProvider handler', () => {
       const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
       const data = await handler.getType();
       expect(data).to.deep.equal({ provider: 'twilio' });
+    });
+
+    it('should throw an error for all other failed requests', async () => {
+      const auth0 = {
+        guardian: {
+          getPhoneFactorSelectedProvider: () => {
+            const error = new Error('Bad request');
+            error.statusCode = 500;
+            throw error;
+          }
+        }
+      };
+
+      const handler = new guardianPhoneFactorSelectedProvider.default({ client: auth0 });
+      try {
+        await handler.getType();
+      } catch (error) {
+        expect(error).to.be.an.instanceOf(Error);
+      }
     });
   });
 
@@ -61,7 +141,7 @@ describe('#guardianPhoneFactorSelectedProvider handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [
-        { guardianPhoneFactorSelectedProvider: null }
+        { guardianPhoneFactorSelectedProvider: {} }
       ]);
     });
   });

--- a/tests/auth0/handlers/guardianPolicies.tests.js
+++ b/tests/auth0/handlers/guardianPolicies.tests.js
@@ -12,7 +12,7 @@ describe('#guardianPolicies handler', () => {
 
       const handler = new guardianPolicies.default({ client: auth0 });
       const data = await handler.getType();
-      expect(data).to.deep.equal(null);
+      expect(data).to.deep.equal({});
     });
 
     it('should get guardian policies', async () => {
@@ -24,7 +24,9 @@ describe('#guardianPolicies handler', () => {
 
       const handler = new guardianPolicies.default({ client: auth0 });
       const data = await handler.getType();
-      expect(data).to.deep.equal([ 'all-applications' ]);
+      expect(data).to.deep.equal({
+        policies: [ 'all-applications' ]
+      });
     });
   });
 
@@ -44,7 +46,11 @@ describe('#guardianPolicies handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [
-        { guardianPolicies: [ 'all-applications' ] }
+        {
+          guardianPolicies: {
+            policies: [ 'all-applications' ]
+          }
+        }
       ]);
     });
 
@@ -62,7 +68,7 @@ describe('#guardianPolicies handler', () => {
       const stageFn = Object.getPrototypeOf(handler).processChanges;
 
       await stageFn.apply(handler, [
-        { guardianPolicies: null }
+        { guardianPolicies: {} }
       ]);
     });
   });

--- a/tests/auth0/validator.tests.js
+++ b/tests/auth0/validator.tests.js
@@ -361,33 +361,35 @@ describe('#schema validation tests', () => {
 
   describe('#guardianPolicies validate', () => {
     it('should fail validation if guardianPolicies is not an array of strings', (done) => {
-      const data = [ {
-        anything: 'anything'
-      } ];
+      const data = {
+        policies: 'all-applications'
+      };
 
-      const auth0 = new Auth0({}, { guardianPolicies: data }, {});
-
-      auth0.validate().then(failedCb(done), passedCb(done, 'should be string'));
+      checkTypeError('policies', 'array', { guardianPolicies: data }, done);
     });
 
     it('should pass validation', (done) => {
-      const data = [ 'all-applications' ];
+      const data = {
+        policies: [ 'all-applications' ]
+      };
 
       checkPassed({ guardianPolicies: data }, done);
     });
 
     it('should allow empty array', (done) => {
-      const data = [];
+      const data = {
+        policies: []
+      };
 
       checkPassed({ guardianPolicies: data }, done);
     });
   });
 
   describe('#guardianPhoneFactorSelectedProvider validate', () => {
-    it('should fail validation if no "provider" provided', (done) => {
+    it('should pass validation if no "provider" provided', (done) => {
       const data = {};
 
-      checkRequired('provider', { guardianPhoneFactorSelectedProvider: data }, done);
+      checkPassed({ guardianPhoneFactorSelectedProvider: data }, done);
     });
 
     it('should pass validation', (done) => {
@@ -398,10 +400,10 @@ describe('#schema validation tests', () => {
   });
 
   describe('#guardianPhoneFactorMessageTypes validate', () => {
-    it('should fail validation if no "message_types" provided', (done) => {
+    it('should pass validation if no "message_types" provided', (done) => {
       const data = {};
 
-      checkRequired('message_types', { guardianPhoneFactorMessageTypes: data }, done);
+      checkPassed({ guardianPhoneFactorMessageTypes: data }, done);
     });
 
     it('should pass validation', (done) => {


### PR DESCRIPTION
## ✏️ Changes
  
Fixes a bug introduced in https://github.com/auth0-extensions/auth0-source-control-extension-tools/pull/96.


#### Better error handling for not-yet-supported Voice MFA endpoints

#96 introduced support for guardian phone factor message types and phone factor selected provider, but given that the features are still in BETA, some customers might receive an HTTP `404` or HTTP `403` when calling the corresponding endpoint.

In this PR, we add some error handling that skips processing these settings if the management API returns one of these error conditions.

#### Remodel guardian policies

For guardian policies, I had to change the representation of the policies, going from an array of string to an object with a `policies` attribute.

Before:
```
guardianPolicies: ['all-applications']
```
After:
```
guardianPolicies: {
  policies: ['all-applications']
}
```

This is to better handle the case when the latest version of the auth0-source-control-extension-tools library is installed with auth0-deploy-cli@5.0.0 (which does not deal well when the feature is modeled as an array of strings).
  
## 📷 Screenshots
 
If there were visual changes to the application with this change, please include before and after screenshots here. If it has animation, please use screen capture software like  to make a gif.
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/MFA-351
  
## 🎯 Testing

- Install auth0-deploy-cli@5.0.0 but also install this PR as its auth0-source-control-extension-tools dependencies (`npm link` works).
- Run a round of manual tests of the deploy-cli and ensure that this error does not appear:
```
2020-07-05T03:40:28.629Z - info: Retrieving guardianPhoneFactorMessageTypes data from Auth0
Oh no, something went wrong. Error: Error: Problem loading tenant data from Auth0 Not Found: Not Found
```
- Test against a tenant that has an old version of Management API (a version that is missing the endpoint altogether).
- Test against a tenant for which the endpoint is disabled (via the feature flag).

   
🚫 This change has been tested in a Webtask

✅ This change has been tested locally
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
