### PR TITLE
fix(migrations): handle 404 error for older installations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.1",
+  "version": "4.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/migrations.js
+++ b/src/auth0/handlers/migrations.js
@@ -16,8 +16,13 @@ export default class MigrationsHandler extends DefaultHandler {
   }
 
   async getType() {
-    const migrations = await this.client.migrations.getMigrations();
-    return migrations.flags;
+    try {
+      const migrations = await this.client.migrations.getMigrations();
+      return migrations.flags;
+    } catch (err) {
+      if (err.statusCode === 404) return {};
+      throw err;
+    }
   }
 
   // Run at the end since switching a flag will depend on other applying other changes

--- a/tests/auth0/handlers/migrations.tests.js
+++ b/tests/auth0/handlers/migrations.tests.js
@@ -28,6 +28,36 @@ describe('#migrations handler', () => {
         migration_flag: true
       });
     });
+
+    it('should support when endpoint does not exist (older installations)', async () => {
+      const client = {
+        migrations: {
+          getMigrations: () => {
+            const err = new Error('Not Found');
+            err.name = 'Not Found';
+            err.statusCode = 404;
+            err.requestInfo = {
+              method: 'get',
+              url: 'https://example.auth0.com/api/v2/migrations'
+            };
+            err.originalError = new Error('Not Found');
+            err.originalError.status = 404;
+            err.originalError.response = {
+              body: {
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'Not Found'
+              }
+            };
+            return Promise.reject(err);
+          }
+        }
+      };
+
+      const handler = new migrations({ client });
+      const data = await handler.getType();
+      expect(data).to.deep.equal({});
+    });
   });
 
   describe('#migrations process', () => {


### PR DESCRIPTION
## ✏️ Changes
  
Fixes a bug introduced in #97

The `GET /api/v2/migrations` has recently been added to our Management API in cloud environments, but some PSaaS customers do not have that endpoint yet. For those customers, handle the HTTP `404` error by skipping processing of migrations (return an empty object).
  
## 📷 Screenshots
 
⛔ 
  
## 🔗 References
  
Ticket = https://auth0team.atlassian.net/servicedesk/customer/portal/34/ESD-7469
  
## 🎯 Testing
  
Run deploy-cli 5.1.0 with an older PSaaS installation.
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment

✅ This can be deployed any time
  
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
