### PR TITLE
docs: add note about breaking older PSaaS installations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -57,6 +57,8 @@ We will rollback if …
   
 > Explain how the rollback for this change will look like, how we can recover fast.
  
-## 🖥 Appliance
+## 🖥 PSaaS
   
-**Note to reviewers:** ensure that this change is compatible with the Appliance.
+**Note to reviewers:** ensure that this change is compatible with the PSaaS.
+
+> Check that any newly introduced handler will gracefully handle the case when Deploy CLI is run against an older PSaaS installation, where the endpoint is not yet deployed. This usually means handling the HTTP 404 status code.


### PR DESCRIPTION
## ✏️ Changes
  
Update the PR template to mention the special case of older PSaaS installation (they are usually lagging our cloud environments by at least a few weeks). For these environments, we need to ensure that any new handler gracefully handles when the endpoint has not yet been rolled out (and returns an HTTP 404 from our Management API). This PR adds a note the bring attention to this special case.
  
## 📷 Screenshots
 
⛔ 
  
## 🔗 References
  
Related bugfix: https://github.com/auth0-extensions/auth0-source-control-extension-tools/pull/101
  
