### PR TITLE
fix: using pagination for requests

### DIFF
--- a/src/auth0/handlers/clientGrants.js
+++ b/src/auth0/handlers/clientGrants.js
@@ -38,7 +38,7 @@ export default class ClientHandler extends DefaultHandler {
     if (this.existing) {
       return this.existing;
     }
-    this.existing = this.client.clientGrants.getAll({ paginate: true });
+    this.existing = await this.client.clientGrants.getAll({ paginate: true });
 
     // Always filter out the client we are using to access Auth0 Management API
     // As it could cause problems if the grants are deleted or updated etc

--- a/src/auth0/handlers/rulesConfigs.js
+++ b/src/auth0/handlers/rulesConfigs.js
@@ -26,7 +26,7 @@ export default class RulesConfigsHandler extends DefaultHandler {
   }
 
   async getType() {
-    return this.client.rulesConfigs.getAll({ paginate: true });
+    return this.client.rulesConfigs.getAll();
   }
 
   objString(item) {

--- a/tests/auth0/validator.tests.js
+++ b/tests/auth0/validator.tests.js
@@ -4,7 +4,22 @@ import Auth0 from '../../src/auth0';
 describe('#schema validation tests', () => {
   const client = {
     rules: {
-      getAll: () => []
+      getAll: async () => ({ rules: [] })
+    },
+    clients: {
+      getAll: async () => ({ clients: [] })
+    },
+    connections: {
+      getAll: async () => ({ connections: [] })
+    },
+    resourceServers: {
+      getAll: async () => ({ resource_servers: [] })
+    },
+    clientGrants: {
+      getAll: async () => ({ client_grants: [] })
+    },
+    roles: {
+      getAll: async () => ({ client_grants: [] })
     }
   };
 


### PR DESCRIPTION
## ✏️ Changes
  
The code to perform paginated requests was not being hit, since the proxy was defined in top of the client instead of the resource managers. This caused requests to be sent passing `paginate=true` to Management API, but no pagination was performed.

 ## 🎯 Testing
     
✅ This change has been tested in a Webtask
Has been tested on top of auth0-deploy-cli.
 
✅ This change has unit test coverage
  
✅ This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
    