### PR TITLE
[ESD-ESD-7795] fix disable connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/connections.js
+++ b/src/auth0/handlers/connections.js
@@ -67,22 +67,36 @@ export default class ConnectionsHandler extends DefaultHandler {
 
     // Convert enabled_clients by name to the id
     const clients = await this.client.clients.getAll({ paginate: true });
+    const existingConexions = await this.client.connections.getAll();
     const excludedClientsByNames = (assets.exclude && assets.exclude.clients) || [];
     const excludedClients = convertClientNamesToIds(excludedClientsByNames, clients);
-
-    const formatted = assets.connections.map(connection => ({
-      ...connection,
-      ...this.getFormattedOptions(connection, clients),
-      enabled_clients: [
+    const formatted = assets.connections.map((connection) => {
+      const enabledClients = [
         ...convertClientNamesToIds(
           connection.enabled_clients || [],
           clients
         ).filter(
           item => ![ ...excludedClientsByNames, ...excludedClients ].includes(item)
         )
-      ]
-    }));
+      ];
+      // If client is excluded and in the existing connection this client is enabled, it should keep enabled
+      // If client is excluded and in the existing connection this client is disabled, it should keep disabled
+      existingConexions.forEach((conn) => {
+        if (conn.name === connection.name) {
+          excludedClients.forEach((excludedClient) => {
+            if (conn.enabled_clients.includes(excludedClient)) {
+              enabledClients.push(excludedClient);
+            }
+          });
+        }
+      });
 
+      return ({
+        ...connection,
+        ...this.getFormattedOptions(connection, clients),
+        enabled_clients: enabledClients
+      });
+    });
     return super.calcChanges({ ...assets, connections: formatted });
   }
 

--- a/src/auth0/handlers/databases.js
+++ b/src/auth0/handlers/databases.js
@@ -68,17 +68,33 @@ export default class DatabaseHandler extends DefaultHandler {
 
     // Convert enabled_clients by name to the id
     const clients = await this.client.clients.getAll({ paginate: true });
+    const existingDatabasesConecctions = await this.client.connections.getAll({ strategy: 'auth0', paginate: true });
     const excludedClientsByNames = (assets.exclude && assets.exclude.clients) || [];
     const excludedClients = convertClientNamesToIds(excludedClientsByNames, clients);
     const formatted = databases.map((db) => {
       if (db.enabled_clients) {
+        const enabledClients = db.enabled_clients.map((name) => {
+          const found = clients.find(c => c.name === name);
+          if (found) return found.client_id;
+          return name;
+        }).filter(item => ![ ...excludedClientsByNames, ...excludedClients ].includes(item));
+
+
+        // If client is excluded and in the existing connection this client is enabled, it should keep enabled
+        // If client is excluded and in the existing connection this client is disabled, it should keep disabled
+        existingDatabasesConecctions.forEach((existingDb) => {
+          if (existingDb.name === db.name) {
+            excludedClients.forEach((excludedClient) => {
+              if (existingDb.enabled_clients.includes(excludedClient)) {
+                enabledClients.push(excludedClient);
+              }
+            });
+          }
+        });
+
         return {
           ...db,
-          enabled_clients: db.enabled_clients.map((name) => {
-            const found = clients.find(c => c.name === name);
-            if (found) return found.client_id;
-            return name;
-          }).filter(item => ![ ...excludedClientsByNames, ...excludedClients ].includes(item))
+          enabled_clients: enabledClients
         };
       }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -163,6 +163,31 @@ export function stripFields(obj, fields) {
   return newObj;
 }
 
+export function getEnabledClients(assets, connection, existing, clients) {
+  // Convert enabled_clients by name to the id
+  const excludedClientsByNames = (assets.exclude && assets.exclude.clients) || [];
+  const excludedClients = convertClientNamesToIds(excludedClientsByNames, clients);
+  const enabledClients = [
+    ...convertClientNamesToIds(
+      connection.enabled_clients || [],
+      clients
+    ).filter(
+      item => ![ ...excludedClientsByNames, ...excludedClients ].includes(item)
+    )
+  ];
+  // If client is excluded and in the existing connection this client is enabled, it should keep enabled
+  // If client is excluded and in the existing connection this client is disabled, it should keep disabled
+  existing.forEach((conn) => {
+    if (conn.name === connection.name) {
+      excludedClients.forEach((excludedClient) => {
+        if (conn.enabled_clients.includes(excludedClient)) {
+          enabledClients.push(excludedClient);
+        }
+      });
+    }
+  });
+  return enabledClients;
+}
 
 export function duplicateItems(arr, key) {
   // Find duplicates objects within array that have the same key value

--- a/tests/auth0/handlers/connections.tests.js
+++ b/tests/auth0/handlers/connections.tests.js
@@ -313,8 +313,9 @@ describe('#connections handler', () => {
       await stageFn.apply(handler, [ { connections: data } ]);
     });
 
-
-    it('should omit excluded clients', async () => {
+    // If client is excluded and in the existing connection this client is enabled, it should keep enabled
+    // If client is excluded and in the existing connection this client is disabled, it should keep disabled
+    it('should handle excluded clients properly', async () => {
       const auth0 = {
         connections: {
           create: (data) => {
@@ -325,19 +326,22 @@ describe('#connections handler', () => {
             expect(params).to.be.an('object');
             expect(params.id).to.equal('con1');
             expect(data).to.deep.equal({
-              enabled_clients: [ 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' ],
+              enabled_clients: [ 'client1-id', 'excluded-one-id' ],
               options: { passwordPolicy: 'testPolicy' }
             });
 
             return Promise.resolve({ ...params, ...data });
           },
           delete: () => Promise.resolve([]),
-          getAll: () => [ { name: 'someConnection', id: 'con1', strategy: 'custom' } ]
+          getAll: () => [ {
+            name: 'someConnection', id: 'con1', strategy: 'custom', enabled_clients: [ 'excluded-one-id' ]
+          } ]
         },
         clients: {
           getAll: () => [
-            { name: 'client1', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Tec' },
-            { name: 'excluded-one', client_id: 'YwqVtt8W3pw5AuEz3B2Kse9l2Ruy7Teb' }
+            { name: 'client1', client_id: 'client1-id' },
+            { name: 'excluded-one', client_id: 'excluded-one-id' },
+            { name: 'excluded-two', client_id: 'excluded-two-id' }
           ]
         },
         pool


### PR DESCRIPTION
## ✏️ Changes
  
For a client the connections are disabled when the client is added AUTH0_EXCLUDED_CLIENTS list.

This fix takes into account the existing connections for the client to decide if the connection should be enabled or disabled:

If the client is excluded and in the existing connection this client is enabled, it should keep enabled.
If the client is excluded and in the existing connection this client is disabled, it should keep disabled
  
## 🔗 References
 
https://auth0team.atlassian.net/browse/ESD-7795
  
## 🎯 Testing
  
✅ This change has integration test coverage
  
