### PR TITLE
Client grants fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,12 @@ export function convertClientNameToId(name, clients) {
 }
 
 export function convertClientNamesToIds(names, clients) {
-  return names.map(name => convertClientNameToId(name, clients));
+  return clients.reduce((acc, client) => {
+    if (names.includes(client.name)) {
+      acc.push(client.client_id);
+    }
+    return acc;
+  }, []);
 }
 
 export function loadFile(file, mappings) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,12 +26,17 @@ export function convertClientNameToId(name, clients) {
 }
 
 export function convertClientNamesToIds(names, clients) {
-  return clients.reduce((acc, client) => {
+  const resolvedNames = names.map(name => ({ name, resolved: false }));
+  const result = clients.reduce((acc, client) => {
     if (names.includes(client.name)) {
+      const index = resolvedNames.findIndex(item => item.name === client.name);
+      resolvedNames[index].resolved = true;
       acc.push(client.client_id);
     }
     return acc;
   }, []);
+  const unresolved = resolvedNames.filter(item => !item.resolved).map(item => item.name);
+  return [ ...unresolved, ...result ];
 }
 
 export function loadFile(file, mappings) {

--- a/tests/auth0/handlers/clientGrants.tests.js
+++ b/tests/auth0/handlers/clientGrants.tests.js
@@ -366,4 +366,113 @@ describe('#clientGrants handler', () => {
       await stageFn.apply(handler, [ assets ]);
     });
   });
+  it.only('should not delete client grants of excluded clients with multiple instances', async () => {
+    config.data = {
+      AUTH0_CLIENT_ID: 'client_id',
+      AUTH0_ALLOW_DELETE: true
+    };
+
+    const auth0 = {
+      clientGrants: {
+        create: (params) => {
+          expect(params).to.be.an('undefined');
+
+          return Promise.resolve([]);
+        },
+        update: (params) => {
+          expect(params).to.be.an('undefined');
+
+          return Promise.resolve([]);
+        },
+        delete: (params) => {
+          expect(params).to.be.an('undefined');
+
+          return Promise.resolve([]);
+        },
+        getAll: () => [
+          {
+            client_id: '123',
+            audience: 'a',
+            id: '1'
+          },
+          {
+            client_id: '123',
+            audience: 'a',
+            id: '2'
+          },
+          {
+            client_id: '123',
+            audience: 'a',
+            id: '3'
+          },
+          {
+            client_id: '456',
+            audience: 'a',
+            id: '4'
+          },
+          {
+            client_id: '456',
+            audience: 'a',
+            id: '5'
+          }
+        ]
+      },
+      clients: {
+        getAll: () => [
+          {
+            name: 'abc',
+            client_id: 'abc'
+          },
+          {
+            name: 'foo_client',
+            client_id: '123'
+          },
+          {
+            name: 'foo_client',
+            client_id: '456'
+          }
+        ]
+      },
+      pool
+    };
+
+    const handler = new clientGrants.default({ client: auth0, config });
+    const stageFn = Object.getPrototypeOf(handler).processChanges;
+
+    const assets = {
+      clients: [
+        {
+          name: 'foo_client'
+        },
+        {
+          name: 'foo_client'
+        }
+      ],
+      clientGrants: [
+        {
+          client_id: 'foo_client',
+          audience: 'https://example.com'
+        },
+        {
+          client_id: 'foo_client',
+          audience: 'https://example.com'
+        },
+        {
+          client_id: 'foo_client',
+          audience: 'https://example.com'
+        },
+        {
+          client_id: 'foo_client',
+          audience: 'https://example.com'
+        },
+        {
+          client_id: 'foo_client',
+          audience: 'https://example.com'
+        }
+      ],
+      exclude: { clients: [ 'foo_client' ] }
+    };
+
+    await stageFn.apply(handler, [ assets ]);
+  });
 });

--- a/tests/auth0/handlers/clientGrants.tests.js
+++ b/tests/auth0/handlers/clientGrants.tests.js
@@ -366,7 +366,7 @@ describe('#clientGrants handler', () => {
       await stageFn.apply(handler, [ assets ]);
     });
   });
-  it.only('should not delete client grants of excluded clients with multiple instances', async () => {
+  it('should not delete client grants of excluded clients with multiple instances', async () => {
     config.data = {
       AUTH0_CLIENT_ID: 'client_id',
       AUTH0_ALLOW_DELETE: true

--- a/tests/utils.tests.js
+++ b/tests/utils.tests.js
@@ -106,9 +106,9 @@ describe('#utils', function() {
 
     const names = [ 'dd', 'cc', 'aa' ];
 
-    const expected = [ 'dd', '3', '1' ];
+    const expected = [ '1', '3', 'dd' ];
 
-    expect(utils.convertClientNamesToIds(names, clients)).to.deep.equal(expected);
+    expect(utils.convertClientNamesToIds(names, clients).sort()).to.deep.equal(expected);
   });
 });
 


### PR DESCRIPTION
## ✏️ Changes
  
In scenarios where multiple clients exist with the same name, and that client name was used in `AUTH0_EXCLUDED_CLIENTS`, the library was mistakenly deleting some Client Grants.

This was due to a utility function used to resolve names into IDs. When multiple clients with the same name existed, it only returned the `client_id` of the first client it encountered with a matching name, instead of returning all of the associated `client_id`s for a given client name. 
  
## 🔗 References
  
ESD-8476
  
## 🎯 Testing
  
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  