### PR TITLE
[DXEX-1038] fix: use pagination in API calls 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/connections.js
+++ b/src/auth0/handlers/connections.js
@@ -67,7 +67,7 @@ export default class ConnectionsHandler extends DefaultHandler {
 
     // Convert enabled_clients by name to the id
     const clients = await this.client.clients.getAll({ paginate: true });
-    const existingConexions = await this.client.connections.getAll();
+    const existingConexions = await this.client.connections.getAll({ paginate: true });
     const formatted = assets.connections.map(connection => (
       {
         ...connection,

--- a/src/auth0/handlers/pages.js
+++ b/src/auth0/handlers/pages.js
@@ -41,7 +41,7 @@ export default class PageHandler extends DefaultHandler {
   }
 
   async updateLoginPage(page) {
-    const globalClient = await this.client.clients.getAll({ is_global: true });
+    const globalClient = await this.client.clients.getAll({ is_global: true, paginate: true });
 
     if (!globalClient[0]) {
       throw new Error('Unable to find global client id when trying to update the login page');
@@ -86,7 +86,7 @@ export default class PageHandler extends DefaultHandler {
     const pages = [];
 
     // Login page is handled via the global client
-    const globalClient = await this.client.clients.getAll({ is_global: true });
+    const globalClient = await this.client.clients.getAll({ is_global: true, paginate: true });
     if (!globalClient[0]) {
       throw new Error('Unable to find global client id when trying to dump the login page');
     }


### PR DESCRIPTION
## ✏️ Changes

 - Fixed a call to `/connections` endpoint that missing the pagination parameter.
 - Fixed a call to `/clients` endpoint that missing the pagination parameter.
  
## 🔗 References

- https://auth0team.atlassian.net/browse/DXEX-1038
  
## 🎯 Testing
   
🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
  
✅ This can be deployed any time
  
## 🎡 Rollout

User/client of this package should upgrade to the new release with this change
 
## 🔥 Rollback
  
User/client of this package should downgrade to an earlier release known to work
