### PR TITLE
[ESD-9513] a0deploy hooks export failed but no error reported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/hooks.js
+++ b/src/auth0/handlers/hooks.js
@@ -154,7 +154,7 @@ export default class HooksHandler extends DefaultHandler {
 
       return this.existing;
     } catch (err) {
-      if (err.statusCode === 404 || err.statusCode === 403 || err.statusCode === 501) {
+      if (err.statusCode === 404 || err.statusCode === 501) {
         return [];
       }
       throw err;

--- a/tests/auth0/handlers/hooks.tests.js
+++ b/tests/auth0/handlers/hooks.tests.js
@@ -254,23 +254,6 @@ describe('#hooks handler', () => {
       expect(data).to.deep.equal([]);
     });
 
-    it('should return an empty array for 403 status code', async () => {
-      const auth0 = {
-        hooks: {
-          getAll: () => {
-            const error = new Error('This endpoint is disabled for your tenant.');
-            error.statusCode = 403;
-            throw error;
-          }
-        },
-        pool
-      };
-
-      const handler = new hooks.default({ client: auth0, config });
-      const data = await handler.getType();
-      expect(data).to.deep.equal([]);
-    });
-
     it('should throw an error for all other failed requests', async () => {
       const auth0 = {
         hooks: {


### PR DESCRIPTION
## ✏️ Changes
  
For hooks, 403 errors are being masked and an empty list is being returned. This fix changes the previous behaviour to report this errors as expected.
  
## References
 
https://auth0team.atlassian.net/browse/ESD-9513
  