### PR TITLE
add `verify_email_by_code` email template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -58,6 +58,7 @@ constants.DATABASE_SCRIPTS_IMPORT = [
 constants.EMAIL_TEMPLATES_DIRECTORY = 'emails';
 
 constants.EMAIL_VERIFY = 'verify_email';
+constants.EMAIL_VERIFY_BY_CODE = 'verify_email_by_code';
 constants.EMAIL_RESET = 'reset_email';
 constants.EMAIL_WELCOME = 'welcome_email';
 constants.EMAIL_BLOCKED = 'blocked_account';
@@ -70,6 +71,8 @@ constants.EMAIL_MFA_OOB_CODE = 'mfa_oob_code';
 constants.EMAIL_TEMPLATES_NAMES = [
   constants.EMAIL_VERIFY + '.json',
   constants.EMAIL_VERIFY + '.html',
+  constants.EMAIL_VERIFY_BY_CODE + '.json',
+  constants.EMAIL_VERIFY_BY_CODE + '.html',
   constants.EMAIL_RESET + '.json',
   constants.EMAIL_RESET + '.html',
   constants.EMAIL_WELCOME + '.json',
@@ -90,6 +93,7 @@ constants.EMAIL_TEMPLATES_NAMES = [
 
 constants.EMAIL_TEMPLATES_TYPES = [
   'verify_email',
+  'verify_email_by_code',
   'reset_email',
   'welcome_email',
   'blocked_account',


### PR DESCRIPTION
## ✏️ Changes

Add a new email template key `verify_email_by_code`, to support the "Verification Email (using Code)" template that was introduced in the past few months in the dashboard:
![image](https://user-images.githubusercontent.com/1411117/105085136-576ead80-5a65-11eb-8a11-6a227d3d4abb.png)

This is required in order to address the issue reported here: https://github.com/auth0/auth0-deploy-cli/issues/303

⚠️ this will require a version bump of auth0-source-control-extension-tools in https://github.com/auth0/auth0-deploy-cli

## 🎯 Testing

🚫 This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance

## 🚀 Deployment

✅ This can be deployed any time