### PR TITLE
MFA-997 Add webauthn platform as a supported factor

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -114,7 +114,8 @@ constants.GUARDIAN_FACTORS = [
   'otp',
   'email',
   'duo',
-  'webauthn-roaming'
+  'webauthn-roaming',
+  'webauthn-platform'
 ];
 constants.GUARDIAN_POLICIES = [
   'all-applications',

--- a/tests/auth0/handlers/guardianFactors.tests.js
+++ b/tests/auth0/handlers/guardianFactors.tests.js
@@ -62,7 +62,8 @@ describe('#guardianFactors handler', () => {
         { name: 'otp', enabled: true },
         { name: 'email', enabled: true },
         { name: 'duo', enabled: false },
-        { name: 'webauthn-roaming', enabled: false }
+        { name: 'webauthn-roaming', enabled: false },
+        { name: 'webauthn-platform', enabled: false }
       ];
 
       const auth0 = {
@@ -84,7 +85,8 @@ describe('#guardianFactors handler', () => {
         { name: 'otp', enabled: true },
         { name: 'email', enabled: true },
         { name: 'duo', enabled: false },
-        { name: 'webauthn-roaming', enabled: false }
+        { name: 'webauthn-roaming', enabled: false },
+        { name: 'webauthn-platform', enabled: false }
       ];
 
       const auth0 = {


### PR DESCRIPTION
## ✏️ Changes

Adding support for webauthn-platform factor.

I followed the example of https://github.com/auth0-extensions/auth0-source-control-extension-tools/pull/115

## 🔗 References

https://auth0team.atlassian.net/browse/MFA-997

✅ This change has unit test coverage
