### PR TITLE
feat: whitelist user-invitation email template

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -67,6 +67,7 @@ constants.EMAIL_ENROLLMENT = 'enrollment_email';
 constants.EMAIL_CHANGE_PASSWORD = 'change_password';
 constants.EMAIL_PASSWORD_RESET = 'password_reset';
 constants.EMAIL_MFA_OOB_CODE = 'mfa_oob_code';
+constants.EMAIL_USER_INVITATION = 'user_invitation';
 
 constants.EMAIL_TEMPLATES_NAMES = [
   constants.EMAIL_VERIFY + '.json',
@@ -88,7 +89,9 @@ constants.EMAIL_TEMPLATES_NAMES = [
   constants.EMAIL_PASSWORD_RESET + '.json',
   constants.EMAIL_PASSWORD_RESET + '.html',
   constants.EMAIL_MFA_OOB_CODE + '.json',
-  constants.EMAIL_MFA_OOB_CODE + '.html'
+  constants.EMAIL_MFA_OOB_CODE + '.html',
+  constants.EMAIL_USER_INVITATION + '.json',
+  constants.EMAIL_USER_INVITATION + '.html'
 ];
 
 constants.EMAIL_TEMPLATES_TYPES = [
@@ -101,7 +104,8 @@ constants.EMAIL_TEMPLATES_TYPES = [
   'enrollment_email',
   'mfa_oob_code',
   'change_password',
-  'password_reset'
+  'password_reset',
+  'user_invitation'
 ];
 
 constants.GUARDIAN_DIRECTORY = 'guardian';


### PR DESCRIPTION
## ✏️ Changes

This PR adds `user-invitation` email template type to whitelist. The template type is supported by auth0 management API but not whitelisted in the extension-tools. 

## 🔗 References

https://auth0.com/docs/api/management/v2?_ga=2.78377239.2071533785.1617019012-783567391.1598615059#!/Email_Templates/get_email_templates_by_templateName

## 🎯 Testing

🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance

## 🚀 Deployment

✅ This can be deployed any time
