### PR TITLE
[ESD-12815] Fix excluded enabled clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/auth0/handlers/connections.js
+++ b/src/auth0/handlers/connections.js
@@ -72,7 +72,7 @@ export default class ConnectionsHandler extends DefaultHandler {
       {
         ...connection,
         ...this.getFormattedOptions(connection, clients),
-        ...(connection.enabled_clients && { enabled_clients: getEnabledClients(assets, connection, existingConnections, clients) })
+        ...(connection.enabled_clients && { enabled_clients: getEnabledClients(assets, connection, existingConexions, clients) })
       }
     ));
     return super.calcChanges({ ...assets, connections: formatted });

--- a/src/auth0/handlers/connections.js
+++ b/src/auth0/handlers/connections.js
@@ -72,7 +72,7 @@ export default class ConnectionsHandler extends DefaultHandler {
       {
         ...connection,
         ...this.getFormattedOptions(connection, clients),
-        enabled_clients: getEnabledClients(assets, connection, existingConexions, clients)
+        ...(connection.enabled_clients && { enabled_clients: getEnabledClients(assets, connection, existingConnections, clients) })
       }
     ));
     return super.calcChanges({ ...assets, connections: formatted });


### PR DESCRIPTION
## ✏️ Changes

Before this fix, when the enabled_clients field inside a connection is undefined, it was changed by an empty list, this had as a consequence that all the enabled clients for the connections were deleted.

## 🔗 References

https://auth0team.atlassian.net/browse/ESD-12815

## 🎯 Testing

This fix was tested locally

## 🚀 Deployment

✅. This can be deployed any time

