### PR TITLE
MFA-1174 Support Recovery Codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-source-control-extension-tools",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "Supporting tools for the Source Control extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -120,7 +120,8 @@ constants.GUARDIAN_FACTORS = [
   'email',
   'duo',
   'webauthn-roaming',
-  'webauthn-platform'
+  'webauthn-platform',
+  'recovery-code'
 ];
 constants.GUARDIAN_POLICIES = [
   'all-applications',

--- a/tests/auth0/handlers/guardianFactors.tests.js
+++ b/tests/auth0/handlers/guardianFactors.tests.js
@@ -63,7 +63,8 @@ describe('#guardianFactors handler', () => {
         { name: 'email', enabled: true },
         { name: 'duo', enabled: false },
         { name: 'webauthn-roaming', enabled: false },
-        { name: 'webauthn-platform', enabled: false }
+        { name: 'webauthn-platform', enabled: false },
+        { name: 'recovery-code', enabled: false }
       ];
 
       const auth0 = {
@@ -86,7 +87,8 @@ describe('#guardianFactors handler', () => {
         { name: 'email', enabled: true },
         { name: 'duo', enabled: false },
         { name: 'webauthn-roaming', enabled: false },
-        { name: 'webauthn-platform', enabled: false }
+        { name: 'webauthn-platform', enabled: false },
+        { name: 'recovery-code', enabled: false }
       ];
 
       const auth0 = {


### PR DESCRIPTION
## ✏️ Changes

Updating the allowed factors to support optional recovery codes in our upcoming feature

## 🔗 References
https://auth0team.atlassian.net/browse/MFA-1088

## 🎯 Testing

Testing e2e in vivaldi with deploy cli 

✅ This change has unit test coverage

🚫 This change has integration test coverage

🚫 This change has been tested for performance

## 🚀 Deployment

I believe this can be merged anytime, but the version bump in auth0 deploy cli might need to wait

✅🚫 This can be deployed any time
